### PR TITLE
Issue 30 - Fix browser "Search feature" doesn't match with page content

### DIFF
--- a/src/app/pages/bitfield/bitfield.component.ts
+++ b/src/app/pages/bitfield/bitfield.component.ts
@@ -20,7 +20,7 @@ interface BitfieldData {
 }
 
 @Component({
-  selector: 'bitfield',
+  selector: 'ndb-page-bitfield',
   standalone: true,
   imports: [
     AsyncPipe,

--- a/src/app/pages/bookmarks/bookmarks.component.ts
+++ b/src/app/pages/bookmarks/bookmarks.component.ts
@@ -16,7 +16,7 @@ interface BookmarkItem {
 }
 
 @Component({
-  selector: 'bookmarks',
+  selector: 'ndb-page-bookmarks',
   standalone: true,
   imports: [
     AsyncPipe,

--- a/src/app/pages/enum/enum.component.ts
+++ b/src/app/pages/enum/enum.component.ts
@@ -20,7 +20,7 @@ interface EnumData {
 }
 
 @Component({
-  selector: 'enum',
+  selector: 'ndb-page-enum',
   standalone: true,
   imports: [
     AsyncPipe,

--- a/src/app/pages/function/function.component.ts
+++ b/src/app/pages/function/function.component.ts
@@ -11,7 +11,7 @@ import {RecentVisitService} from "../../../shared/services/recent-visit.service"
 import {MatTooltip} from "@angular/material/tooltip";
 
 @Component({
-  selector: 'function',
+  selector: 'ndb-page-function',
   standalone: true,
   imports: [
     AsyncPipe,

--- a/src/app/pages/functions/functions.component.ts
+++ b/src/app/pages/functions/functions.component.ts
@@ -16,7 +16,7 @@ interface FunctionsData {
 }
 
 @Component({
-  selector: 'functions',
+  selector: 'ndb-page-functions',
   standalone: true,
   imports: [
     AsyncPipe,

--- a/src/app/pages/import/import.component.ts
+++ b/src/app/pages/import/import.component.ts
@@ -32,7 +32,7 @@ interface BehaviorItem {
 }
 
 @Component({
-  selector: 'import',
+  selector: 'ndb-page-import',
   standalone: true,
   imports: [
     AsyncPipe,

--- a/src/app/pages/object/object.component.ts
+++ b/src/app/pages/object/object.component.ts
@@ -91,7 +91,7 @@ interface BadgeFilterItem<T> {
 }
 
 @Component({
-  selector: 'object',
+  selector: 'ndb-page-object',
   standalone: true,
   imports: [
     AsyncPipe,

--- a/src/app/pages/readme/readme.component.ts
+++ b/src/app/pages/readme/readme.component.ts
@@ -16,7 +16,7 @@ import {MatDialog} from "@angular/material/dialog";
 import {NDBGuidelinesDialogComponent} from "../../components/ndb-guidelines-dialog/ndb-guidelines-dialog.component";
 
 @Component({
-  selector: 'readme',
+  selector: 'ndb-page-readme',
   standalone: true,
   imports: [
     AsyncPipe,

--- a/src/app/pages/recent-visits/recent-visits.component.ts
+++ b/src/app/pages/recent-visits/recent-visits.component.ts
@@ -17,7 +17,7 @@ interface RecentVisitData {
 }
 
 @Component({
-  selector: 'recent-visits',
+  selector: 'ndb-page-recent-visits',
   standalone: true,
   imports: [
     AsyncPipe,

--- a/src/app/pages/settings/settings.component.ts
+++ b/src/app/pages/settings/settings.component.ts
@@ -16,7 +16,7 @@ interface AItem<T> {
 }
 
 @Component({
-  selector: 'settings',
+  selector: 'ndb-page-settings',
   standalone: true,
   imports: [
     MatFormFieldModule,


### PR DESCRIPTION
Selector 'object' of component ObjectComponent collides with external `<object>` element.
Rename all pages with prefix 'ndb-page-' to be uniform and to prevent collision with existing DOM elements.

Closes #30.