### PR TITLE
Issue 33 - Add shortcuts to open a definition in a new tab/window

### DIFF
--- a/src/app/components/spans/type-span/type-span.component.html
+++ b/src/app/components/spans/type-span/type-span.component.html
@@ -35,12 +35,12 @@
         @case (redscript) {
           <span class="stx-type redirect"
                 [class.disabled]="isEmpty"
-                (click)="onRedirect()">{{node.aliasName ?? node.name}}</span>
+                (mouseup)="onRedirect($event)">{{node.aliasName ?? node.name}}</span>
         }
         @default {
           <span class="stx-type redirect"
                 [class.disabled]="isEmpty"
-                (click)="onRedirect()">{{node.name}}</span>
+                (mouseup)="onRedirect($event)">{{node.name}}</span>
         }
       }
     }

--- a/src/app/components/spans/type-span/type-span.component.ts
+++ b/src/app/components/spans/type-span/type-span.component.ts
@@ -41,8 +41,15 @@ export class TypeSpanComponent {
     return RedTypeAst.isPrimitive(this.node);
   }
 
-  onRedirect(): void {
-    this.routerService.navigateTo(this.node!.id);
+  /**
+   * Navigate to node's page on a simple click.
+   * Open node's page in a new tab on CTRL+CLICK, CMD+CLICK or Middle Mouse Button.
+   * @param event
+   */
+  onRedirect(event: MouseEvent): void {
+    let inTab: boolean = event.ctrlKey || event.metaKey || event.button === 1;
+
+    this.routerService.navigateTo(this.node!.id, inTab);
   }
 
 }

--- a/src/shared/services/router.service.spec.ts
+++ b/src/shared/services/router.service.spec.ts
@@ -5,6 +5,9 @@ import {Observable, of} from "rxjs";
 import {RedNodeAst} from "../red-ast/red-node.ast";
 import {AstHelper} from "../../../tests/ast.helper";
 import {cyrb53} from "../string";
+import {mockWindowOpen} from "../../../tests/window.mock";
+import Spy = jasmine.Spy;
+import Mock = jest.Mock;
 
 jest.mock("./red-dump.service");
 
@@ -94,6 +97,87 @@ describe('RouterService', () => {
 
       // THEN
       expect(routerMock.navigate).toHaveBeenCalledWith(['s', id]);
+    });
+  });
+
+  describe('navigateTo(id, inTab: true)', () => {
+    let openMock: any;
+
+    beforeAll(() => {
+      openMock = mockWindowOpen();
+    });
+
+    it('given unknown id then don\'t change current route', async () => {
+      // GIVEN
+      const observer: Observable<RedNodeAst | undefined> = of(undefined);
+
+      dumpMock.getById.mockReturnValue(observer);
+
+      // WHEN
+      await service.navigateTo(0, true);
+
+      // THEN
+      expect(openMock).not.toHaveBeenCalled();
+    });
+
+    it('given id of an enum then navigate to /e/:id', async () => {
+      // GIVEN
+      const id: number = cyrb53('Test');
+      const observer: Observable<RedNodeAst | undefined> = of(AstHelper.buildEnum('Test'));
+
+      dumpMock.getById.mockReturnValue(observer);
+      routerMock.serializeUrl.mockReturnValue(`/e/${id}`);
+
+      // WHEN
+      await service.navigateTo(id, true);
+
+      // THEN
+      expect(openMock).toHaveBeenCalledWith(`/e/${id}`, '_blank');
+    });
+
+    it('given id of a bitfield then navigate to /b/:id', async () => {
+      // GIVEN
+      const id: number = cyrb53('Test');
+      const observer: Observable<RedNodeAst | undefined> = of(AstHelper.buildBitfield('Test'));
+
+      dumpMock.getById.mockReturnValue(observer);
+      routerMock.serializeUrl.mockReturnValue(`/b/${id}`);
+
+      // WHEN
+      await service.navigateTo(id, true);
+
+      // THEN
+      expect(openMock).toHaveBeenCalledWith(`/b/${id}`, '_blank');
+    });
+
+    it('given id of a class then navigate to /c/:id', async () => {
+      // GIVEN
+      const id: number = cyrb53('Test');
+      const observer: Observable<RedNodeAst | undefined> = of(AstHelper.buildClass('Test'));
+
+      dumpMock.getById.mockReturnValue(observer);
+      routerMock.serializeUrl.mockReturnValue(`/c/${id}`);
+
+      // WHEN
+      await service.navigateTo(id, true);
+
+      // THEN
+      expect(openMock).toHaveBeenCalledWith(`/c/${id}`, '_blank');
+    });
+
+    it('given id of a struct then navigate to /s/:id', async () => {
+      // GIVEN
+      const id: number = cyrb53('Test');
+      const observer: Observable<RedNodeAst | undefined> = of(AstHelper.buildStruct('Test'));
+
+      dumpMock.getById.mockReturnValue(observer);
+      routerMock.serializeUrl.mockReturnValue(`/s/${id}`);
+
+      // WHEN
+      await service.navigateTo(id, true);
+
+      // THEN
+      expect(openMock).toHaveBeenCalledWith(`/s/${id}`, '_blank');
     });
   });
 });

--- a/src/shared/services/router.service.ts
+++ b/src/shared/services/router.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from "@angular/core";
 import {RedDumpService} from "./red-dump.service";
 import {RedNodeAst, RedNodeKind} from "../red-ast/red-node.ast";
-import {Router} from "@angular/router";
+import {Router, UrlTree} from "@angular/router";
 import {firstValueFrom} from "rxjs";
 
 @Injectable({
@@ -13,7 +13,7 @@ export class RouterService {
               private readonly router: Router) {
   }
 
-  async navigateTo(id: number): Promise<void> {
+  async navigateTo(id: number, inTab: boolean = false): Promise<void> {
     const node: RedNodeAst | undefined = await firstValueFrom(this.dumpService.getById(id));
 
     if (node === undefined) {
@@ -22,7 +22,14 @@ export class RouterService {
     }
     const root: string = RedNodeKind[node.kind][0];
 
-    await this.router.navigate([root, id]);
+    if (inTab) {
+      const urlTree: UrlTree = this.router.createUrlTree([root, id]);
+      const url: string = this.router.serializeUrl(urlTree);
+
+      window.open(url, '_blank');
+    } else {
+      await this.router.navigate([root, id]);
+    }
   }
 
 }

--- a/tests/angular/router.mock.ts
+++ b/tests/angular/router.mock.ts
@@ -1,7 +1,11 @@
 export const RouterMock = {
   navigate: jest.fn(),
+  createUrlTree: jest.fn(),
+  serializeUrl: jest.fn(),
 
   mockResetAll() {
     RouterMock.navigate.mockReset();
+    RouterMock.createUrlTree.mockReset();
+    RouterMock.serializeUrl.mockReset();
   }
 }

--- a/tests/window.mock.ts
+++ b/tests/window.mock.ts
@@ -7,6 +7,10 @@ export function mockLocation(path: string): void {
   window.location = new URL(`https://nativedb.com${path}`);
 }
 
+export function mockWindowOpen(): any {
+  return jest.spyOn(window, 'open').mockImplementation();
+}
+
 export interface MatchMediaMock {
   mediaQuery: Mock<MediaQueryList>;
   listener?: Function;


### PR DESCRIPTION
Support CTRL+CLICK, CMD+CLICK and Middle Mouse Button.
Include unit tests.

Closes #33.