### PR TITLE
Improve performance with a SharedWorker instead of Workers

### DIFF
--- a/src/shared/services/red-dump.worker.ts
+++ b/src/shared/services/red-dump.worker.ts
@@ -30,7 +30,7 @@ const data: RedDumpData = {
 let isReady: boolean = false;
 
 (async () => {
-  if (typeof 'onconnect' !== 'undefined') {
+  if (typeof SharedWorker !== 'undefined') {
     // SharedWorker
     addEventListener('connect', onConnection);
   } else {

--- a/src/shared/services/red-dump.worker.ts
+++ b/src/shared/services/red-dump.worker.ts
@@ -15,6 +15,7 @@ interface RedDumpData {
   objects: RedClassAst[];
   classes: RedClassAst[];
   structs: RedClassAst[];
+  badges: number;
 }
 
 const data: RedDumpData = {
@@ -23,45 +24,34 @@ const data: RedDumpData = {
   functions: [],
   objects: [],
   classes: [],
-  structs: []
+  structs: [],
+  badges: 0
 };
+let isReady: boolean = false;
 
 (async () => {
-  addEventListener('message', onMessage);
-
-  data.enums = await loadEnums();
-  data.bitfields = await loadBitfields();
-  data.functions = await loadFunctions();
-  data.objects = await loadObjects();
-  const nodes: RedNodeAst[] = [...data.enums, ...data.bitfields, ...data.functions, ...data.objects];
-
-  data.classes = data.objects.filter((object) => !object.isStruct);
-  data.structs = data.objects.filter((object) => object.isStruct);
-  const badges: number = computeBadges(data.objects);
-
-  send(NDBCommand.rd_load, <RedDumpWorkerLoad>{
-    enums: data.enums,
-    bitfields: data.bitfields,
-    functions: data.functions,
-    classes: data.classes,
-    structs: data.structs,
-    badges: badges
-  });
-
-  loadAliases(nodes);
-
-  send(NDBCommand.rd_load_aliases, <RedDumpWorkerLoadAliases>{
-    functions: data.functions,
-    classes: data.classes,
-    structs: data.structs
-  });
+  if (typeof 'onconnect' !== 'undefined') {
+    // SharedWorker
+    addEventListener('connect', onConnection);
+  } else {
+    // Worker
+    addEventListener('message', onMessage);
+    await load();
+  }
 })();
 
 const commands: NDBCommandHandler[] = [
   {command: NDBCommand.rd_load_inheritance, fn: onLoadInheritance}
 ];
 
-function onMessage(event: MessageEvent): void {
+async function onConnection(event: any): Promise<void> {
+  const port: MessagePort = event.ports[0];
+
+  port.onmessage = (message: MessageEvent) => onMessage(message, port);
+  await load(port);
+}
+
+function onMessage(event: MessageEvent, port?: MessagePort): void {
   const message: NDBMessage = event.data as NDBMessage;
   const handler: NDBCommandHandler | undefined = commands.find((item) => item.command === message.command);
 
@@ -69,29 +59,78 @@ function onMessage(event: MessageEvent): void {
     console.warn('RedDumpWorker: unknown command.');
     return;
   }
-  handler.fn(message.data);
+  handler.fn(message.data, port);
 }
 
-function onLoadInheritance(id: number): void {
+async function load(port?: MessagePort): Promise<void> {
+  if (isReady) {
+    send(NDBCommand.rd_load, port, <RedDumpWorkerLoad>{
+      enums: data.enums,
+      bitfields: data.bitfields,
+      functions: data.functions,
+      classes: data.classes,
+      structs: data.structs,
+      badges: data.badges
+    });
+    return;
+  }
+  data.enums = await loadEnums();
+  data.bitfields = await loadBitfields();
+  data.functions = await loadFunctions();
+  data.objects = await loadObjects();
+
+  data.classes = data.objects.filter((object) => !object.isStruct);
+  data.structs = data.objects.filter((object) => object.isStruct);
+  data.badges = computeBadges(data.objects);
+
+  send(NDBCommand.rd_load, port, <RedDumpWorkerLoad>{
+    enums: data.enums,
+    bitfields: data.bitfields,
+    functions: data.functions,
+    classes: data.classes,
+    structs: data.structs,
+    badges: data.badges
+  });
+
+  const nodes: RedNodeAst[] = [...data.enums, ...data.bitfields, ...data.functions, ...data.objects];
+
+  loadAliases(nodes);
+
+  send(NDBCommand.rd_load_aliases, port, <RedDumpWorkerLoadAliases>{
+    functions: data.functions,
+    classes: data.classes,
+    structs: data.structs
+  });
+  isReady = true;
+}
+
+function onLoadInheritance(id: number, port?: MessagePort): void {
   const object: RedClassAst | undefined = data.objects.find((object) => object.id === id);
 
   if (!object) {
     return;
   }
   if (object.isInheritanceLoaded) {
+    send(NDBCommand.rd_load_inheritance, port, [object.id, object.parents, object.children]);
     return;
   }
   loadParents(data.objects, object);
   loadChildren(data.objects, object);
   object.isInheritanceLoaded = true;
-  send(NDBCommand.rd_load_inheritance, [object.id, object.parents, object.children]);
+  send(NDBCommand.rd_load_inheritance, port, [object.id, object.parents, object.children]);
 }
 
-function send(command: NDBCommand, data?: any): void {
-  postMessage(<NDBMessage>{
+function send(command: NDBCommand, port?: MessagePort, data?: any): void {
+  const message: NDBMessage = <NDBMessage>{
     command: command,
     data: data
-  });
+  };
+
+  if (port) {
+    port.postMessage(message);
+  } else {
+    postMessage(message);
+  }
 }
 
 function computeBadges(objects: RedClassAst[]): number {

--- a/src/shared/worker.common.ts
+++ b/src/shared/worker.common.ts
@@ -1,3 +1,5 @@
+import {NgZone} from "@angular/core";
+
 export enum NDBCommand {
   // Documentation
   ready,
@@ -23,5 +25,55 @@ export interface NDBMessage {
 
 export interface NDBCommandHandler {
   readonly command: NDBCommand;
-  readonly fn: (data: any) => void | Promise<void>;
+  readonly fn: (data: any, port?: MessagePort) => void | Promise<void>;
+}
+
+type WorkerMessageCallback = (event: MessageEvent) => void;
+
+/**
+ * Custom worker facade to send/receive messages with either a Worker or a SharedWorker.
+ * Fallback to a worker per tab when SharedWorker is not supported (e.g. Chrome Android).
+ */
+export class NDBWorker {
+
+  // Worker object is created outside to resolve URL in the right place when bundling is triggered.
+  // NgZone is required to run message callbacks in Angular context.
+  constructor(private readonly worker: Worker | SharedWorker,
+              private readonly ngZone: NgZone) {
+  }
+
+  set onmessage(fn: WorkerMessageCallback) {
+    if (this.worker instanceof Worker) {
+      this.worker.onmessage = this.injectMessage(fn);
+    } else if (this.worker instanceof SharedWorker) {
+      this.worker.port.onmessage = this.injectMessage(fn);
+    }
+  }
+
+  public static isCompatible(): boolean {
+    return typeof Worker !== 'undefined' || typeof SharedWorker !== 'undefined';
+  }
+
+  public postMessage(message: any): void {
+    if (this.worker instanceof Worker) {
+      this.worker.postMessage(message);
+    } else if (this.worker instanceof SharedWorker) {
+      this.worker.port.postMessage(message);
+    }
+  }
+
+  public terminate(): void {
+    if (this.worker instanceof Worker) {
+      this.worker.terminate();
+    } else if (this.worker instanceof SharedWorker) {
+      this.worker.port.close();
+    }
+  }
+
+  private injectMessage(fn: WorkerMessageCallback): WorkerMessageCallback {
+    return (event: MessageEvent) => {
+      this.ngZone.run(() => fn(event));
+    };
+  }
+
 }


### PR DESCRIPTION
Use a SharedWorker across tabs/windows to load RTTI dumps.
Fallback to Worker when browser isn't compatible.