### PR TITLE
Copy code features for Redscript and Lua

### DIFF
--- a/src/app/components/spans/function-span/function-span.component.html
+++ b/src/app/components/spans/function-span/function-span.component.html
@@ -37,7 +37,8 @@
             }
           } @else if (fmtService.syntax === CodeSyntax.lua) {
             <mat-divider></mat-divider>
-            <button mat-menu-item (click)="copySpecial('Observable')">Copy Observable</button>
+            <button mat-menu-item (click)="copySpecial('Observe')">Copy Observe</button>
+            <button mat-menu-item (click)="copySpecial('ObserveAfter')">Copy ObserveAfter</button>
             <button mat-menu-item (click)="copySpecial('Override')">Copy Override</button>
             <button mat-menu-item (click)="copySpecial('NewProxy')">Copy NewProxy</button>
           }

--- a/src/app/components/spans/function-span/function-span.component.html
+++ b/src/app/components/spans/function-span/function-span.component.html
@@ -11,7 +11,37 @@
                 class="badge clipboard"
                 matTooltip="Copy code to clipboard"
                 matTooltipShowDelay="1500"
-                (click)="copyToClipboard()"><mat-icon>content_copy</mat-icon></button>
+                [matMenuTriggerFor]="copyMenu"><mat-icon>content_copy</mat-icon></button>
+        <mat-menu #copyMenu="matMenu">
+          <button mat-menu-item (click)="copyPrototype()">Copy prototype</button>
+          <button mat-menu-item (click)="copyCall()">Copy call</button>
+          @if (fmtService.syntax === CodeSyntax.redscript) {
+            <mat-divider></mat-divider>
+            @if (!memberOf) {
+              <button mat-menu-item
+                      [disabled]="node.isNative"
+                      matTooltip="You cannot replace a native global method."
+                      [matTooltipDisabled]="!node.isNative"
+                      (click)="copySpecial('replaceGlobal')">Copy replaceGlobal</button>
+            } @else {
+              <button mat-menu-item
+                      [disabled]="node.isNative"
+                      matTooltip="You cannot wrap a native method."
+                      [matTooltipDisabled]="!node.isNative"
+                      (click)="copySpecial('wrapMethod')">Copy wrapMethod</button>
+              <button mat-menu-item
+                      [disabled]="node.isNative"
+                      matTooltip="You cannot replace a native method."
+                      [matTooltipDisabled]="!node.isNative"
+                      (click)="copySpecial('replaceMethod')">Copy replaceMethod</button>
+            }
+          } @else if (fmtService.syntax === CodeSyntax.lua) {
+            <mat-divider></mat-divider>
+            <button mat-menu-item (click)="copySpecial('Observable')">Copy Observable</button>
+            <button mat-menu-item (click)="copySpecial('Override')">Copy Override</button>
+            <button mat-menu-item (click)="copySpecial('NewProxy')">Copy NewProxy</button>
+          }
+        </mat-menu>
       }
       @if (canDocument) {
         <button mat-icon-button

--- a/src/app/components/spans/function-span/function-span.component.html
+++ b/src/app/components/spans/function-span/function-span.component.html
@@ -40,7 +40,11 @@
             <button mat-menu-item (click)="copySpecial('Observe')">Copy Observe</button>
             <button mat-menu-item (click)="copySpecial('ObserveAfter')">Copy ObserveAfter</button>
             <button mat-menu-item (click)="copySpecial('Override')">Copy Override</button>
-            <button mat-menu-item (click)="copySpecial('NewProxy')">Copy NewProxy</button>
+            <button mat-menu-item
+                    matTooltip="Only for Listener classes"
+                    [matTooltipDisabled]="isListener"
+                    [disabled]="!isListener"
+                    (click)="copySpecial('NewProxy')">Copy NewProxy</button>
           }
         </mat-menu>
       }

--- a/src/app/components/spans/function-span/function-span.component.ts
+++ b/src/app/components/spans/function-span/function-span.component.ts
@@ -196,7 +196,7 @@ export class FunctionSpanComponent {
     await navigator.clipboard.writeText(data);
   }
 
-  private onShowDocumentation([state, ]: [boolean, ClassDocumentation | undefined]): void {
+  private onShowDocumentation([state,]: [boolean, ClassDocumentation | undefined]): void {
     if (!this.hasDocumentation) {
       return;
     }

--- a/src/app/components/spans/function-span/function-span.component.ts
+++ b/src/app/components/spans/function-span/function-span.component.ts
@@ -149,7 +149,7 @@ export class FunctionSpanComponent {
     if (!this.node) {
       return;
     }
-    const code: string = this.fmtService.formatCode(this.node, this.memberOf);
+    const code: string = this.fmtService.formatCall(this.node, this.memberOf);
 
     await navigator.clipboard.writeText(code);
   }

--- a/src/app/components/spans/function-span/function-span.component.ts
+++ b/src/app/components/spans/function-span/function-span.component.ts
@@ -52,13 +52,13 @@ export class FunctionSpanComponent {
 
   scope: string = '';
   hasFullName: boolean = false;
+  isListener: boolean = false;
 
   node?: RedFunctionAst;
 
   /**
    * Optional, when this function is a member of a class or a struct.
    */
-  @Input()
   memberOf?: RedClassAst;
 
   /**
@@ -99,6 +99,12 @@ export class FunctionSpanComponent {
     this.node = value;
     this.scope = (this.node) ? RedVisibilityDef[this.node.visibility] : '';
     this.hasFullName = !!this.node && (this.node.name !== this.node.fullName);
+  }
+
+  @Input('memberOf')
+  set _memberOf(value: RedClassAst | undefined) {
+    this.memberOf = value;
+    this.isListener = !!this.memberOf && (this.memberOf.aliasName ?? this.memberOf.name).endsWith('Listener');
   }
 
   @Input('documentation')

--- a/src/app/components/spans/function-span/function-span.component.ts
+++ b/src/app/components/spans/function-span/function-span.component.ts
@@ -9,12 +9,14 @@ import {RedClassAst} from "../../../../shared/red-ast/red-class.ast";
 import {RedVisibilityDef} from "../../../../shared/red-ast/red-definitions.ast";
 import {NDBDocumentationComponent} from "../../ndb-documentation/ndb-documentation.component";
 import {ClassDocumentation} from "../../../../shared/services/documentation.service";
-import {SettingsService} from "../../../../shared/services/settings.service";
+import {CodeSyntax, SettingsService} from "../../../../shared/services/settings.service";
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 import {BehaviorSubject, combineLatest, Observable} from "rxjs";
 import {CodeFormatterService} from "../../../../shared/services/code-formatter.service";
 import {MatTooltipModule} from "@angular/material/tooltip";
 import {RouterLink} from "@angular/router";
+import {MatMenu, MatMenuItem, MatMenuTrigger} from "@angular/material/menu";
+import {MatDivider} from "@angular/material/divider";
 
 @Component({
   selector: 'function-span',
@@ -22,6 +24,10 @@ import {RouterLink} from "@angular/router";
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     RouterLink,
+    MatMenu,
+    MatMenuItem,
+    MatMenuTrigger,
+    MatDivider,
     MatIconModule,
     MatButtonModule,
     MatTooltipModule,
@@ -75,10 +81,12 @@ export class FunctionSpanComponent {
 
   documentation?: ClassDocumentation;
 
+  protected readonly CodeSyntax = CodeSyntax;
+
   private readonly documentationSubject: BehaviorSubject<ClassDocumentation | undefined> = new BehaviorSubject<ClassDocumentation | undefined>(undefined);
   private readonly documentation$: Observable<ClassDocumentation | undefined> = this.documentationSubject.asObservable();
 
-  constructor(private readonly fmtService: CodeFormatterService,
+  constructor(protected readonly fmtService: CodeFormatterService,
               private readonly settingsService: SettingsService) {
     combineLatest([
       this.settingsService.showDocumentation$,
@@ -145,11 +153,29 @@ export class FunctionSpanComponent {
     await navigator.clipboard.writeText(this.node.fullName);
   }
 
-  protected async copyToClipboard(): Promise<void> {
+  protected async copyPrototype(): Promise<void> {
+    if (!this.node) {
+      return;
+    }
+    const code: string = this.fmtService.formatPrototype(this.node);
+
+    await navigator.clipboard.writeText(code);
+  }
+
+  protected async copyCall(): Promise<void> {
     if (!this.node) {
       return;
     }
     const code: string = this.fmtService.formatCall(this.node, this.memberOf);
+
+    await navigator.clipboard.writeText(code);
+  }
+
+  protected async copySpecial(type: string): Promise<void> {
+    if (!this.node) {
+      return;
+    }
+    const code: string = this.fmtService.formatSpecial(type, this.node, this.memberOf);
 
     await navigator.clipboard.writeText(code);
   }

--- a/src/app/pages/settings/settings.component.ts
+++ b/src/app/pages/settings/settings.component.ts
@@ -32,7 +32,7 @@ interface AItem<T> {
 export class SettingsComponent implements OnInit {
 
   readonly clipboardOptions: AItem<CodeSyntax>[] = [
-    {value: CodeSyntax.redscript, name: 'Redscript', disabled: true},
+    {value: CodeSyntax.redscript, name: 'Redscript', disabled: false},
     {value: CodeSyntax.lua, name: 'Lua · CET', disabled: false},
     {value: CodeSyntax.cppRedLib, name: 'C++ · RedLib', disabled: false},
   ];

--- a/src/shared/formatters/cpp-redlib.formatter.ts
+++ b/src/shared/formatters/cpp-redlib.formatter.ts
@@ -19,6 +19,14 @@ export class CppRedLibFormatter extends CodeFormatter {
     this.formatCodePipe = new NDBFormatCodePipe();
   }
 
+  override formatPrototype(func: RedFunctionAst): string {
+    return '';
+  }
+
+  override formatSpecial(type: string, func: RedFunctionAst, memberOf?: RedClassAst): string {
+    return '';
+  }
+
   protected override formatSelf(func: RedFunctionAst, memberOf?: RedClassAst | undefined): CodeVariableFormat | undefined {
     if (func.isStatic || !memberOf) {
       return undefined;

--- a/src/shared/formatters/formatter.ts
+++ b/src/shared/formatters/formatter.ts
@@ -17,6 +17,13 @@ export abstract class CodeFormatter {
   }
 
   /**
+   * Format prototype of a function to code based on implementation syntax.
+   * @param func to format prototype of.
+   * undefined.
+   */
+  abstract formatPrototype(func: RedFunctionAst): string;
+
+  /**
    * Format call of a function to code based on implementation syntax.
    * @param func to call and format to code.
    * @param memberOf optionally provide scope of the function: static, member of a class/struct or global when
@@ -66,6 +73,15 @@ export abstract class CodeFormatter {
     code += '\n';
     return code;
   }
+
+  /**
+   * Format function to code based on implementation syntax for a special feature.
+   * @param type of special feature to format to.
+   * @param func to format to code.
+   * @param memberOf optionally provide scope of the function: static, member of a class/struct or global when
+   * undefined.
+   */
+  abstract formatSpecial(type: string, func: RedFunctionAst, memberOf?: RedClassAst): string;
 
   protected formatReturnName(func: RedFunctionAst): string {
     let fnName: string = func.name;

--- a/src/shared/formatters/formatter.ts
+++ b/src/shared/formatters/formatter.ts
@@ -1,6 +1,5 @@
 import {RedFunctionAst} from "../red-ast/red-function.ast";
 import {RedClassAst} from "../red-ast/red-class.ast";
-import {RedArgumentAst} from "../red-ast/red-argument.ast";
 
 export interface CodeVariableFormat {
   readonly prefix: string;

--- a/src/shared/formatters/formatter.ts
+++ b/src/shared/formatters/formatter.ts
@@ -23,7 +23,7 @@ export abstract class CodeFormatter {
    * @param memberOf optionally provide scope of the function: static, member of a class/struct or global when
    * undefined.
    */
-  formatCode(func: RedFunctionAst, memberOf?: RedClassAst): string {
+  formatCall(func: RedFunctionAst, memberOf?: RedClassAst): string {
     const hasFullName: boolean = func.name !== func.fullName;
     const selfVar: CodeVariableFormat | undefined = this.formatSelf(func, memberOf);
     const selfName: string | undefined = (hasFullName && selfVar && !func.isStatic) ? selfVar.name : undefined;

--- a/src/shared/formatters/lua.formatter.spec.ts
+++ b/src/shared/formatters/lua.formatter.spec.ts
@@ -12,164 +12,411 @@ describe('LuaFormatter', () => {
     fmt = new LuaFormatter();
   });
 
-  it('should format global function', () => {
-    // GIVEN
-    const globalFn: RedFunctionAst = AstHelper.buildFunction(
-      'GetPlayer',
-      AstHelper.buildRef('PlayerPuppet'),
-      true
-    );
+  describe('formatCall()', () => {
+    it('should format global function', () => {
+      // GIVEN
+      const globalFn: RedFunctionAst = AstHelper.buildFunction(
+        'GetPlayer',
+        AstHelper.buildRef('PlayerPuppet'),
+        true
+      );
 
-    // WHEN
-    const code: string = fmt.formatCall(globalFn);
+      // WHEN
+      const code: string = fmt.formatCall(globalFn);
 
-    // THEN
-    expect(code).toBe('local player -- ref<PlayerPuppet>\n' +
-      '\n' +
-      'player = Game.GetPlayer()\n');
-  });
+      // THEN
+      expect(code).toBe('local player -- ref<PlayerPuppet>\n' +
+        '\n' +
+        'player = Game.GetPlayer()\n');
+    });
 
-  it('should format static function', () => {
-    // GIVEN
-    const object: RedClassAst = AstHelper.buildClass('GameTime');
-    const staticFn: RedFunctionAst = AstHelper.buildFunction(
-      'IsAfter',
-      AstHelper.Bool,
-      true,
-      RedVisibilityDef.public,
-      [AstHelper.buildArg('other', 'GameTime')]
-    );
+    it('should format static function', () => {
+      // GIVEN
+      const object: RedClassAst = AstHelper.buildClass('GameTime');
+      const staticFn: RedFunctionAst = AstHelper.buildFunction(
+        'IsAfter',
+        AstHelper.Bool,
+        true,
+        RedVisibilityDef.public,
+        [AstHelper.buildArg('other', 'GameTime')]
+      );
 
-    // WHEN
-    const code: string = fmt.formatCall(staticFn, object);
+      // WHEN
+      const code: string = fmt.formatCall(staticFn, object);
 
-    // THEN
-    expect(code).toBe('local other -- GameTime\n' +
-      'local isAfter -- Bool\n' +
-      '\n' +
-      'isAfter = GameTime.IsAfter(other)\n');
-  });
+      // THEN
+      expect(code).toBe('local other -- GameTime\n' +
+        'local isAfter -- Bool\n' +
+        '\n' +
+        'isAfter = GameTime.IsAfter(other)\n');
+    });
 
-  it('should format static function and ignore full name', () => {
-    // GIVEN
-    const systemObj: RedClassAst = AstHelper.buildClass('gameVehicleSystem', 'VehicleSystem');
-    const staticFn: RedFunctionAst = AstHelper.buildFunction(
-      'IsPlayerInVehicle',
-      AstHelper.Bool,
-      true,
-      RedVisibilityDef.public,
-      [AstHelper.buildArg('game', 'ScriptGameInstance')],
-      'gameVehicleSystem::IsPlayerInVehicle;GameInstance'
-    );
+    it('should format static function and ignore full name', () => {
+      // GIVEN
+      const systemObj: RedClassAst = AstHelper.buildClass('gameVehicleSystem', 'VehicleSystem');
+      const staticFn: RedFunctionAst = AstHelper.buildFunction(
+        'IsPlayerInVehicle',
+        AstHelper.Bool,
+        true,
+        RedVisibilityDef.public,
+        [AstHelper.buildArg('game', 'ScriptGameInstance')],
+        'gameVehicleSystem::IsPlayerInVehicle;GameInstance'
+      );
 
-    // WHEN
-    const code: string = fmt.formatCall(staticFn, systemObj);
+      // WHEN
+      const code: string = fmt.formatCall(staticFn, systemObj);
 
-    // THEN
-    expect(code).toBe('local game -- ScriptGameInstance\n' +
-      'local isPlayerInVehicle -- Bool\n' +
-      '\n' +
-      'isPlayerInVehicle = VehicleSystem.IsPlayerInVehicle(game)\n');
-  });
+      // THEN
+      expect(code).toBe('local game -- ScriptGameInstance\n' +
+        'local isPlayerInVehicle -- Bool\n' +
+        '\n' +
+        'isPlayerInVehicle = VehicleSystem.IsPlayerInVehicle(game)\n');
+    });
 
-  it('should format member function', () => {
-    // GIVEN
-    const vehicleObj: RedClassAst = AstHelper.buildClass('vehicleBaseObject', 'VehicleObject');
-    const memberFn: RedFunctionAst = AstHelper.buildFunction('HasNavPathToTarget',
-      AstHelper.Bool,
-      false,
-      RedVisibilityDef.public,
-      [
-        AstHelper.buildArg('targetID', 'entEntityID'),
-        AstHelper.buildArg('duration', AstHelper.Float),
-        AstHelper.buildArg('invert', AstHelper.Bool)
-      ]
-    );
+    it('should format member function', () => {
+      // GIVEN
+      const vehicleObj: RedClassAst = AstHelper.buildClass('vehicleBaseObject', 'VehicleObject');
+      const memberFn: RedFunctionAst = AstHelper.buildFunction('HasNavPathToTarget',
+        AstHelper.Bool,
+        false,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('targetID', 'entEntityID'),
+          AstHelper.buildArg('duration', AstHelper.Float),
+          AstHelper.buildArg('invert', AstHelper.Bool)
+        ]
+      );
 
-    // WHEN
-    const code: string = fmt.formatCall(memberFn, vehicleObj);
+      // WHEN
+      const code: string = fmt.formatCall(memberFn, vehicleObj);
 
-    // THEN
-    expect(code).toBe('local vehicleobject -- VehicleObject\n' +
-      'local targetID -- entEntityID\n' +
-      'local duration -- Float\n' +
-      'local invert -- Bool\n' +
-      'local navPathToTarget -- Bool\n' +
-      '\n' +
-      'navPathToTarget = vehicleobject:HasNavPathToTarget(targetID, duration, invert)\n');
-  });
+      // THEN
+      expect(code).toBe('local vehicleobject -- VehicleObject\n' +
+        'local targetID -- entEntityID\n' +
+        'local duration -- Float\n' +
+        'local invert -- Bool\n' +
+        'local navPathToTarget -- Bool\n' +
+        '\n' +
+        'navPathToTarget = vehicleobject:HasNavPathToTarget(targetID, duration, invert)\n');
+    });
 
-  it('should format member function and ignore full name', () => {
-    // GIVEN
-    const vehicleObj: RedClassAst = AstHelper.buildClass('vehicleBaseObject', 'VehicleObject');
-    const memberFn: RedFunctionAst = AstHelper.buildFunction('TriggerExitBehavior',
-      undefined,
-      false,
-      RedVisibilityDef.public,
-      [
-        AstHelper.buildArg('maxDelayOverride', AstHelper.Float, true),
-      ],
-      'TriggerExitBehavior;Float'
-    );
+    it('should format member function and ignore full name', () => {
+      // GIVEN
+      const vehicleObj: RedClassAst = AstHelper.buildClass('vehicleBaseObject', 'VehicleObject');
+      const memberFn: RedFunctionAst = AstHelper.buildFunction('TriggerExitBehavior',
+        undefined,
+        false,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('maxDelayOverride', AstHelper.Float, true),
+        ],
+        'TriggerExitBehavior;Float'
+      );
 
-    // WHEN
-    const code: string = fmt.formatCall(memberFn, vehicleObj);
+      // WHEN
+      const code: string = fmt.formatCall(memberFn, vehicleObj);
 
-    // THEN
-    expect(code).toBe('local vehicleobject -- VehicleObject\n' +
-      'local maxDelayOverride -- Float, optional\n' +
-      '\n' +
-      'vehicleobject:TriggerExitBehavior(maxDelayOverride)\n');
-  });
+      // THEN
+      expect(code).toBe('local vehicleobject -- VehicleObject\n' +
+        'local maxDelayOverride -- Float, optional\n' +
+        '\n' +
+        'vehicleobject:TriggerExitBehavior(maxDelayOverride)\n');
+    });
 
-  it('should format global function with an alias', () => {
-    // GIVEN
-    const gameInstanceObj: RedClassAst = AstHelper.buildClass('ScriptGameInstance', 'GameInstance');
-    const globalFn: RedFunctionAst = AstHelper.buildFunction(
-      'GetBlackboardSystem',
-      AstHelper.buildRef('gameBlackboardSystem', 'BlackboardSystem'),
-      true
-    );
+    it('should format global function with an alias', () => {
+      // GIVEN
+      const gameInstanceObj: RedClassAst = AstHelper.buildClass('ScriptGameInstance', 'GameInstance');
+      const globalFn: RedFunctionAst = AstHelper.buildFunction(
+        'GetBlackboardSystem',
+        AstHelper.buildRef('gameBlackboardSystem', 'BlackboardSystem'),
+        true
+      );
 
-    // WHEN
-    const code: string = fmt.formatCall(globalFn, gameInstanceObj);
+      // WHEN
+      const code: string = fmt.formatCall(globalFn, gameInstanceObj);
 
-    // THEN
-    expect(code).toBe('local blackboardSystem -- ref<BlackboardSystem>\n' +
-      '\n' +
-      'blackboardSystem = Game.GetBlackboardSystem()\n');
-  });
+      // THEN
+      expect(code).toBe('local blackboardSystem -- ref<BlackboardSystem>\n' +
+        '\n' +
+        'blackboardSystem = Game.GetBlackboardSystem()\n');
+    });
 
-  it('should format member function without name conflicts', () => {
-    // GIVEN
-    const vehicleComponentObj: RedClassAst = AstHelper.buildClass('VehicleComponent');
-    const memberFn: RedFunctionAst = AstHelper.buildFunction('GetSeats',
-      AstHelper.Bool,
-      true,
-      RedVisibilityDef.public,
-      [
-        AstHelper.buildArg('gi', AstHelper.buildType('ScriptGameInstance', 'GameInstance')),
-        AstHelper.buildArg('vehicle',
-          AstHelper.buildWeakRef('vehicleBaseObject', 'VehicleObject')
-        ),
-        AstHelper.buildArg('seats',
-          AstHelper.buildArray(
-            AstHelper.buildWeakRef('gamedataVehicleSeat_Record', 'VehicleSeat_Record')
+    it('should format member function without name conflicts', () => {
+      // GIVEN
+      const vehicleComponentObj: RedClassAst = AstHelper.buildClass('VehicleComponent');
+      const memberFn: RedFunctionAst = AstHelper.buildFunction('GetSeats',
+        AstHelper.Bool,
+        true,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('gi', AstHelper.buildType('ScriptGameInstance', 'GameInstance')),
+          AstHelper.buildArg('vehicle',
+            AstHelper.buildWeakRef('vehicleBaseObject', 'VehicleObject')
+          ),
+          AstHelper.buildArg('seats',
+            AstHelper.buildArray(
+              AstHelper.buildWeakRef('gamedataVehicleSeat_Record', 'VehicleSeat_Record')
+            )
           )
-        )
-      ]
-    );
+        ]
+      );
 
-    // WHEN
-    const code: string = fmt.formatCall(memberFn, vehicleComponentObj);
+      // WHEN
+      const code: string = fmt.formatCall(memberFn, vehicleComponentObj);
 
-    // THEN
-    expect(code).toEqual('local gi -- GameInstance\n' +
-      'local vehicle -- wref<VehicleObject>\n' +
-      'local seats -- array<wref<VehicleSeat_Record>>\n' +
-      'local result -- Bool\n' +
-      '\n' +
-      'result = VehicleComponent.GetSeats(gi, vehicle, seats)\n');
+      // THEN
+      expect(code).toEqual('local gi -- GameInstance\n' +
+        'local vehicle -- wref<VehicleObject>\n' +
+        'local seats -- array<wref<VehicleSeat_Record>>\n' +
+        'local result -- Bool\n' +
+        '\n' +
+        'result = VehicleComponent.GetSeats(gi, vehicle, seats)\n');
+    });
   });
 
+  describe('formatPrototype()', () => {
+    it('should format empty function', () => {
+      // GIVEN
+      const func: RedFunctionAst = AstHelper.buildFunction('ArraySortInts');
+
+      // WHEN
+      const code: string = fmt.formatPrototype(func);
+
+      // THEN
+      expect(code).toBe('ArraySortInts() -> Void');
+    });
+
+    it('should format function with return type', () => {
+      // GIVEN
+      const func: RedFunctionAst = AstHelper.buildFunction('CanLog', AstHelper.Bool);
+
+      // WHEN
+      const code: string = fmt.formatPrototype(func);
+
+      // THEN
+      expect(code).toBe('CanLog() -> Bool');
+    });
+
+    it('should format function with arguments and return type', () => {
+      // GIVEN
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'Fake',
+        AstHelper.buildArray(AstHelper.buildWeakRef('GameObject')),
+        false,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('a', AstHelper.Float),
+          AstHelper.buildArg('b', AstHelper.buildStruct('Vector4'), false, true),
+          AstHelper.buildArg('c', AstHelper.buildRef('WeaponObject'), true),
+        ]
+      );
+
+      // WHEN
+      const code: string = fmt.formatPrototype(func);
+
+      // THEN
+      expect(code).toBe('Fake(a: Float, out b: Vector4, opt c: ref<WeaponObject>) -> array<wref<GameObject>>');
+    });
+  });
+
+  describe('formatSpecial(\'Observe\')', () => {
+    it('should format member function', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('VehicleComponent');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'PlayHonkForDuration',
+        undefined,
+        false,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('honkTime', AstHelper.Float),
+        ]
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('Observe', func, memberOf);
+
+      // THEN
+      expect(code).toBe(`Observe("VehicleComponent", "PlayHonkForDuration", function(this, honkTime)
+    -- method has just been called with:
+    -- this: VehicleComponent
+    -- honkTime: Float
+end)
+`);
+    });
+
+    it('should format static function w/ fullname', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('VehicleComponent');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'OpenDoor',
+        undefined,
+        true,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('vehicle', AstHelper.buildWeakRef('vehicleBaseObject', 'VehicleObject')),
+          AstHelper.buildArg('vehicleSlotID', AstHelper.buildType('gamemountingMountingSlotId', 'MountingSlotId')),
+          AstHelper.buildArg('delay', AstHelper.Float),
+        ],
+        'OpenDoor;VehicleObjectMountingSlotIdFloat'
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('Observe', func, memberOf);
+
+      // THEN
+      expect(code).toBe(`Observe("VehicleComponent", "OpenDoor;VehicleObjectMountingSlotIdFloat", function(vehicle, vehicleSlotID, delay)
+    -- method has just been called with:
+    -- vehicle: wref<VehicleObject>
+    -- vehicleSlotID: MountingSlotId
+    -- delay: Float
+end)
+`);
+    });
+  });
+
+  describe('formatSpecial(\'ObserveAfter\')', () => {
+    it('should format member function', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('VehicleComponent');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'PlayHonkForDuration',
+        undefined,
+        false,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('honkTime', AstHelper.Float),
+        ]
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('ObserveAfter', func, memberOf);
+
+      // THEN
+      expect(code).toBe(`ObserveAfter("VehicleComponent", "PlayHonkForDuration", function(this, honkTime)
+    -- method has been called and fully executed with:
+    -- this: VehicleComponent
+    -- honkTime: Float
+end)
+`);
+    });
+
+    it('should format static function w/ fullname', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('VehicleComponent');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'OpenDoor',
+        undefined,
+        true,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('vehicle', AstHelper.buildWeakRef('vehicleBaseObject', 'VehicleObject')),
+          AstHelper.buildArg('vehicleSlotID', AstHelper.buildType('gamemountingMountingSlotId', 'MountingSlotId')),
+          AstHelper.buildArg('delay', AstHelper.Float),
+        ],
+        'OpenDoor;VehicleObjectMountingSlotIdFloat'
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('ObserveAfter', func, memberOf);
+
+      // THEN
+      expect(code).toBe(`ObserveAfter("VehicleComponent", "OpenDoor;VehicleObjectMountingSlotIdFloat", function(vehicle, vehicleSlotID, delay)
+    -- method has been called and fully executed with:
+    -- vehicle: wref<VehicleObject>
+    -- vehicleSlotID: MountingSlotId
+    -- delay: Float
+end)
+`);
+    });
+  });
+
+  describe('formatSpecial(\'Override\')', () => {
+    it('should format member function', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('VehicleComponent');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'GetVehicle',
+        AstHelper.buildWeakRef('vehicleBaseObject', 'VehicleObject')
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('Override', func, memberOf);
+
+      // THEN
+      expect(code).toBe(`Override("VehicleComponent", "GetVehicle", function(this, wrappedMethod)
+    -- rewrite method with:
+    -- this: VehicleComponent
+\u0020\u0020\u0020\u0020
+    local result = wrappedMethod()
+\u0020\u0020\u0020\u0020
+    return result
+end)
+`);
+    });
+
+    it('should format static function w/ fullname', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('VehicleComponent');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'CloseDoor',
+        AstHelper.Bool,
+        true,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('vehicle', AstHelper.buildWeakRef('vehicleBaseObject', 'VehicleObject')),
+          AstHelper.buildArg('vehicleSlotID', AstHelper.buildType('gamemountingMountingSlotId', 'MountingSlotId')),
+        ],
+        'CloseDoor;VehicleObjectMountingSlotId'
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('Override', func, memberOf);
+
+      // THEN
+      expect(code).toBe(`Override("VehicleComponent", "CloseDoor;VehicleObjectMountingSlotId", function(vehicle, vehicleSlotID, wrappedMethod)
+    -- rewrite method with:
+    -- vehicle: wref<VehicleObject>
+    -- vehicleSlotID: MountingSlotId
+\u0020\u0020\u0020\u0020
+    local result = wrappedMethod(vehicle, vehicleSlotID)
+\u0020\u0020\u0020\u0020
+    return result
+end)
+`);
+    });
+  });
+
+  // Only with classes ending with Listener in name.
+  describe('formatSpecial(\'NewProxy\')', () => {
+    it('should format with member function', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('GodModeStatListener');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'OnGodModeChanged',
+        undefined,
+        false,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('ownerID', AstHelper.buildType('entEntityID', 'EntityID')),
+          AstHelper.buildArg('newType', AstHelper.buildType('gameGodModeType')),
+        ],
+        'OnGodModeChanged;EntityIDgameGodModeType'
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('NewProxy', func, memberOf);
+
+      // THEN
+      expect(code).toBe(`listener = NewProxy("GodModeStatListener", {
+    OnGodModeChanged = {
+        args = {"EntityID", "gameGodModeType"},
+        callback = function(ownerID, newType)
+            -- Do stuff
+        end
+    }
+})
+`);
+    });
+  });
 });

--- a/src/shared/formatters/lua.formatter.spec.ts
+++ b/src/shared/formatters/lua.formatter.spec.ts
@@ -21,7 +21,7 @@ describe('LuaFormatter', () => {
     );
 
     // WHEN
-    const code: string = fmt.formatCode(globalFn);
+    const code: string = fmt.formatCall(globalFn);
 
     // THEN
     expect(code).toBe('local player -- ref<PlayerPuppet>\n' +
@@ -41,7 +41,7 @@ describe('LuaFormatter', () => {
     );
 
     // WHEN
-    const code: string = fmt.formatCode(staticFn, object);
+    const code: string = fmt.formatCall(staticFn, object);
 
     // THEN
     expect(code).toBe('local other -- GameTime\n' +
@@ -63,7 +63,7 @@ describe('LuaFormatter', () => {
     );
 
     // WHEN
-    const code: string = fmt.formatCode(staticFn, systemObj);
+    const code: string = fmt.formatCall(staticFn, systemObj);
 
     // THEN
     expect(code).toBe('local game -- ScriptGameInstance\n' +
@@ -87,7 +87,7 @@ describe('LuaFormatter', () => {
     );
 
     // WHEN
-    const code: string = fmt.formatCode(memberFn, vehicleObj);
+    const code: string = fmt.formatCall(memberFn, vehicleObj);
 
     // THEN
     expect(code).toBe('local vehicleobject -- VehicleObject\n' +
@@ -113,7 +113,7 @@ describe('LuaFormatter', () => {
     );
 
     // WHEN
-    const code: string = fmt.formatCode(memberFn, vehicleObj);
+    const code: string = fmt.formatCall(memberFn, vehicleObj);
 
     // THEN
     expect(code).toBe('local vehicleobject -- VehicleObject\n' +
@@ -132,7 +132,7 @@ describe('LuaFormatter', () => {
     );
 
     // WHEN
-    const code: string = fmt.formatCode(globalFn, gameInstanceObj);
+    const code: string = fmt.formatCall(globalFn, gameInstanceObj);
 
     // THEN
     expect(code).toBe('local blackboardSystem -- ref<BlackboardSystem>\n' +
@@ -161,7 +161,7 @@ describe('LuaFormatter', () => {
     );
 
     // WHEN
-    const code: string = fmt.formatCode(memberFn, vehicleComponentObj);
+    const code: string = fmt.formatCall(memberFn, vehicleComponentObj);
 
     // THEN
     expect(code).toEqual('local gi -- GameInstance\n' +

--- a/src/shared/formatters/lua.formatter.ts
+++ b/src/shared/formatters/lua.formatter.ts
@@ -11,6 +11,24 @@ export class LuaFormatter extends CodeFormatter {
     super(false);
   }
 
+  override formatPrototype(func: RedFunctionAst): string {
+    const args: string = func.arguments.map((arg) => RedArgumentAst.toString(arg, CodeSyntax.lua)).join(', ');
+    const returnType: string = func.returnType ? RedTypeAst.toString(func.returnType, CodeSyntax.lua) : 'Void';
+
+    return `${func.name}(${args}) -> ${returnType}`;
+  }
+
+  override formatSpecial(type: string, func: RedFunctionAst, memberOf: RedClassAst): string {
+    if (type === 'Observable') {
+      return this.formatObservable(func, memberOf);
+    } else if (type === 'Override') {
+      return this.formatOverride(func, memberOf);
+    } else if (type === 'NewProxy') {
+      return this.formatNewProxy(func, memberOf);
+    }
+    return '';
+  }
+
   protected override formatSelf(func: RedFunctionAst, memberOf?: RedClassAst): CodeVariableFormat | undefined {
     if (func.isStatic || !memberOf) {
       return undefined;
@@ -73,6 +91,18 @@ export class LuaFormatter extends CodeFormatter {
       return 'Game';
     }
     return name;
+  }
+
+  private formatObservable(func: RedFunctionAst, memberOf: RedClassAst): string {
+    return '';
+  }
+
+  private formatOverride(func: RedFunctionAst, memberOf: RedClassAst): string {
+    return '';
+  }
+
+  private formatNewProxy(func: RedFunctionAst, memberOf: RedClassAst): string {
+    return '';
   }
 
 }

--- a/src/shared/formatters/lua.formatter.ts
+++ b/src/shared/formatters/lua.formatter.ts
@@ -176,7 +176,22 @@ export class LuaFormatter extends CodeFormatter {
   }
 
   private formatNewProxy(func: RedFunctionAst, memberOf: RedClassAst): string {
-    return '';
+    const pseudoArgs: string = func.arguments
+      .map((arg) => RedTypeAst.toString(arg.type, CodeSyntax.pseudocode))
+      .map((arg) => `"${arg}"`)
+      .join(', ');
+    const args: string = func.arguments.map((arg) => arg.name).join(', ');
+    let code: string = '';
+
+    code += `listener = NewProxy("${memberOf.aliasName ?? memberOf.name}", {\n`;
+    code += `    ${func.name} = {\n`;
+    code += `        args = {${pseudoArgs}},\n`;
+    code += `        callback = function(${args})\n`;
+    code += '            -- Do stuff\n';
+    code += '        end\n';
+    code += '    }\n';
+    code += '})\n';
+    return code;
   }
 
 }

--- a/src/shared/formatters/lua.formatter.ts
+++ b/src/shared/formatters/lua.formatter.ts
@@ -112,7 +112,7 @@ export class LuaFormatter extends CodeFormatter {
     let code: string = '';
     let after: string = isAfter ? 'After' : '';
 
-    code += `Observe${after}('${memberOf.aliasName ?? memberOf.name}', '${funcName}', function(${callback})\n`;
+    code += `Observe${after}("${memberOf.aliasName ?? memberOf.name}", "${funcName}", function(${callback})\n`;
     if (!isAfter) {
       code += `    -- method has just been called with:\n`;
     } else {
@@ -151,7 +151,7 @@ export class LuaFormatter extends CodeFormatter {
     const args: string = func.arguments.map((arg) => arg.name).join(', ');
     let code: string = '';
 
-    code += `Override('${memberOf.aliasName ?? memberOf.name}', '${funcName}', function(${callback})\n`;
+    code += `Override("${memberOf.aliasName ?? memberOf.name}", "${funcName}", function(${callback})\n`;
     code += '    -- rewrite method with:\n';
     if (!func.isStatic) {
       code += `    -- this: ${memberOf.aliasName ?? memberOf.name}\n`;
@@ -161,15 +161,11 @@ export class LuaFormatter extends CodeFormatter {
     }
     code += '    \n';
     if (func.returnType) {
-      code += `    -- Do stuff before\n`;
       code += `    local result = wrappedMethod(${args})\n`;
       code += '    \n';
-      code += `    -- Do stuff after\n`;
       code += `    return result\n`;
     } else {
-      code += `    -- Do stuff before\n`;
       code += `    wrappedMethod(${args})\n`;
-      code += `    -- Do stuff after\n`;
     }
     code += 'end)\n';
     return code;

--- a/src/shared/formatters/redscript.formatter.spec.ts
+++ b/src/shared/formatters/redscript.formatter.spec.ts
@@ -1,0 +1,424 @@
+import {CodeFormatter} from "./formatter";
+import {AstHelper} from "../../../tests/ast.helper";
+import {RedFunctionAst} from "../red-ast/red-function.ast";
+import {RedVisibilityDef} from "../red-ast/red-definitions.ast";
+import {RedClassAst} from "../red-ast/red-class.ast";
+import {RedscriptFormatter} from "./redscript.formatter";
+
+describe('RedscriptFormatter', () => {
+  let fmt: CodeFormatter;
+
+  beforeAll(() => {
+    fmt = new RedscriptFormatter();
+  });
+
+  /*
+  describe('formatCall()', () => {
+    it('should format global function', () => {
+      // GIVEN
+      const globalFn: RedFunctionAst = AstHelper.buildFunction(
+        'GetPlayer',
+        AstHelper.buildRef('PlayerPuppet'),
+        true
+      );
+
+      // WHEN
+      const code: string = fmt.formatCall(globalFn);
+
+      // THEN
+      expect(code).toBe('local player -- ref<PlayerPuppet>\n' +
+        '\n' +
+        'player = Game.GetPlayer()\n');
+    });
+
+    it('should format static function', () => {
+      // GIVEN
+      const object: RedClassAst = AstHelper.buildClass('GameTime');
+      const staticFn: RedFunctionAst = AstHelper.buildFunction(
+        'IsAfter',
+        AstHelper.Bool,
+        true,
+        RedVisibilityDef.public,
+        [AstHelper.buildArg('other', 'GameTime')]
+      );
+
+      // WHEN
+      const code: string = fmt.formatCall(staticFn, object);
+
+      // THEN
+      expect(code).toBe('local other -- GameTime\n' +
+        'local isAfter -- Bool\n' +
+        '\n' +
+        'isAfter = GameTime.IsAfter(other)\n');
+    });
+
+    it('should format static function and ignore full name', () => {
+      // GIVEN
+      const systemObj: RedClassAst = AstHelper.buildClass('gameVehicleSystem', 'VehicleSystem');
+      const staticFn: RedFunctionAst = AstHelper.buildFunction(
+        'IsPlayerInVehicle',
+        AstHelper.Bool,
+        true,
+        RedVisibilityDef.public,
+        [AstHelper.buildArg('game', 'ScriptGameInstance')],
+        'gameVehicleSystem::IsPlayerInVehicle;GameInstance'
+      );
+
+      // WHEN
+      const code: string = fmt.formatCall(staticFn, systemObj);
+
+      // THEN
+      expect(code).toBe('local game -- ScriptGameInstance\n' +
+        'local isPlayerInVehicle -- Bool\n' +
+        '\n' +
+        'isPlayerInVehicle = VehicleSystem.IsPlayerInVehicle(game)\n');
+    });
+
+    it('should format member function', () => {
+      // GIVEN
+      const vehicleObj: RedClassAst = AstHelper.buildClass('vehicleBaseObject', 'VehicleObject');
+      const memberFn: RedFunctionAst = AstHelper.buildFunction('HasNavPathToTarget',
+        AstHelper.Bool,
+        false,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('targetID', 'entEntityID'),
+          AstHelper.buildArg('duration', AstHelper.Float),
+          AstHelper.buildArg('invert', AstHelper.Bool)
+        ]
+      );
+
+      // WHEN
+      const code: string = fmt.formatCall(memberFn, vehicleObj);
+
+      // THEN
+      expect(code).toBe('local vehicleobject -- VehicleObject\n' +
+        'local targetID -- entEntityID\n' +
+        'local duration -- Float\n' +
+        'local invert -- Bool\n' +
+        'local navPathToTarget -- Bool\n' +
+        '\n' +
+        'navPathToTarget = vehicleobject:HasNavPathToTarget(targetID, duration, invert)\n');
+    });
+
+    it('should format member function and ignore full name', () => {
+      // GIVEN
+      const vehicleObj: RedClassAst = AstHelper.buildClass('vehicleBaseObject', 'VehicleObject');
+      const memberFn: RedFunctionAst = AstHelper.buildFunction('TriggerExitBehavior',
+        undefined,
+        false,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('maxDelayOverride', AstHelper.Float, true),
+        ],
+        'TriggerExitBehavior;Float'
+      );
+
+      // WHEN
+      const code: string = fmt.formatCall(memberFn, vehicleObj);
+
+      // THEN
+      expect(code).toBe('local vehicleobject -- VehicleObject\n' +
+        'local maxDelayOverride -- Float, optional\n' +
+        '\n' +
+        'vehicleobject:TriggerExitBehavior(maxDelayOverride)\n');
+    });
+
+    it('should format global function with an alias', () => {
+      // GIVEN
+      const gameInstanceObj: RedClassAst = AstHelper.buildClass('ScriptGameInstance', 'GameInstance');
+      const globalFn: RedFunctionAst = AstHelper.buildFunction(
+        'GetBlackboardSystem',
+        AstHelper.buildRef('gameBlackboardSystem', 'BlackboardSystem'),
+        true
+      );
+
+      // WHEN
+      const code: string = fmt.formatCall(globalFn, gameInstanceObj);
+
+      // THEN
+      expect(code).toBe('local blackboardSystem -- ref<BlackboardSystem>\n' +
+        '\n' +
+        'blackboardSystem = Game.GetBlackboardSystem()\n');
+    });
+
+    it('should format member function without name conflicts', () => {
+      // GIVEN
+      const vehicleComponentObj: RedClassAst = AstHelper.buildClass('VehicleComponent');
+      const memberFn: RedFunctionAst = AstHelper.buildFunction('GetSeats',
+        AstHelper.Bool,
+        true,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('gi', AstHelper.buildType('ScriptGameInstance', 'GameInstance')),
+          AstHelper.buildArg('vehicle',
+            AstHelper.buildWeakRef('vehicleBaseObject', 'VehicleObject')
+          ),
+          AstHelper.buildArg('seats',
+            AstHelper.buildArray(
+              AstHelper.buildWeakRef('gamedataVehicleSeat_Record', 'VehicleSeat_Record')
+            )
+          )
+        ]
+      );
+
+      // WHEN
+      const code: string = fmt.formatCall(memberFn, vehicleComponentObj);
+
+      // THEN
+      expect(code).toEqual('local gi -- GameInstance\n' +
+        'local vehicle -- wref<VehicleObject>\n' +
+        'local seats -- array<wref<VehicleSeat_Record>>\n' +
+        'local result -- Bool\n' +
+        '\n' +
+        'result = VehicleComponent.GetSeats(gi, vehicle, seats)\n');
+    });
+  });
+  */
+
+  describe('formatPrototype()', () => {
+    it('should format empty function', () => {
+      // GIVEN
+      const func: RedFunctionAst = AstHelper.buildFunction('ArraySortInts');
+
+      // WHEN
+      const code: string = fmt.formatPrototype(func);
+
+      // THEN
+      expect(code).toBe('ArraySortInts() -> Void');
+    });
+
+    it('should format function with return type', () => {
+      // GIVEN
+      const func: RedFunctionAst = AstHelper.buildFunction('CanLog', AstHelper.Bool);
+
+      // WHEN
+      const code: string = fmt.formatPrototype(func);
+
+      // THEN
+      expect(code).toBe('CanLog() -> Bool');
+    });
+
+    it('should format function with arguments and return type', () => {
+      // GIVEN
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'Fake',
+        AstHelper.buildArray(AstHelper.buildWeakRef('GameObject')),
+        false,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('a', AstHelper.Float),
+          AstHelper.buildArg('b', AstHelper.buildStruct('Vector4'), false, true),
+          AstHelper.buildArg('c', AstHelper.buildRef('WeaponObject'), true),
+        ]
+      );
+
+      // WHEN
+      const code: string = fmt.formatPrototype(func);
+
+      // THEN
+      expect(code).toBe('Fake(a: Float, out b: Vector4, opt c: ref<WeaponObject>) -> array<wref<GameObject>>');
+    });
+  });
+
+  describe('formatSpecial(\'wrapMethod\')', () => {
+    it('should not format native function', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('ScriptGameInstance', 'GameInstance');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'FindEntityByID',
+        undefined,
+        true,
+        RedVisibilityDef.public,
+        [],
+        undefined,
+        {isNative: true}
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('wrapMethod', func, memberOf);
+
+      // THEN
+      expect(code).toBe(``);
+    });
+
+    it('should format member function', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('PreventionSystem');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'GetLastAttackTime',
+        AstHelper.Float,
+        false,
+        RedVisibilityDef.public,
+        [],
+        undefined,
+        {isFinal: true, isConst: true}
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('wrapMethod', func, memberOf);
+
+      // THEN
+      expect(code).toBe(`@wrapMethod(PreventionSystem)
+public final const func GetLastAttackTime() -> Float {
+    let result: Float = wrappedMethod();
+\u0020\u0020\u0020\u0020
+    return result;
+}`);
+    });
+
+    it('should format static function', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('PreventionSystem');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'QueueRequest',
+        AstHelper.Bool,
+        true,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('context', 'GameInstance'),
+          AstHelper.buildArg('request', AstHelper.buildRef('ScriptableSystemRequest')),
+          AstHelper.buildArg('delay', AstHelper.Float, true),
+        ],
+        undefined,
+        {isFinal: true}
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('wrapMethod', func, memberOf);
+
+      // THEN
+      expect(code).toBe(`@wrapMethod(PreventionSystem)
+public final static func QueueRequest(context: GameInstance, request: ref<ScriptableSystemRequest>, opt delay: Float) -> Bool {
+    let result: Bool = wrappedMethod(context, request, delay);
+\u0020\u0020\u0020\u0020
+    return result;
+}`);
+    });
+  });
+
+  describe('formatSpecial(\'replaceMethod\')', () => {
+    it('should not format native function', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('ScriptGameInstance', 'GameInstance');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'FindEntityByID',
+        undefined,
+        true,
+        RedVisibilityDef.public,
+        [],
+        undefined,
+        {isNative: true}
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('replaceMethod', func, memberOf);
+
+      // THEN
+      expect(code).toBe(``);
+    });
+
+    it('should format member function', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('PreventionSystem');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'GetLastAttackTime',
+        AstHelper.Float,
+        false,
+        RedVisibilityDef.public,
+        [],
+        undefined,
+        {isFinal: true, isConst: true}
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('replaceMethod', func, memberOf);
+
+      // THEN
+      expect(code).toBe(`@replaceMethod(PreventionSystem)
+public final const func GetLastAttackTime() -> Float {
+    let result: Float;
+\u0020\u0020\u0020\u0020
+    return result;
+}`);
+    });
+
+    it('should format static function', () => {
+      // GIVEN
+      const memberOf: RedClassAst = AstHelper.buildClass('PreventionSystem');
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'QueueRequest',
+        AstHelper.Bool,
+        true,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('context', 'GameInstance'),
+          AstHelper.buildArg('request', AstHelper.buildRef('ScriptableSystemRequest')),
+          AstHelper.buildArg('delay', AstHelper.Float, true),
+        ],
+        undefined,
+        {isFinal: true}
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('replaceMethod', func, memberOf);
+
+      // THEN
+      expect(code).toBe(`@replaceMethod(PreventionSystem)
+public final static func QueueRequest(context: GameInstance, request: ref<ScriptableSystemRequest>, opt delay: Float) -> Bool {
+    let result: Bool;
+\u0020\u0020\u0020\u0020
+    return result;
+}`);
+    });
+  });
+
+  describe('formatSpecial(\'replaceGlobal\')', () => {
+    it('should not format native function', () => {
+      // GIVEN
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'AngleDistance',
+        AstHelper.Float,
+        true,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('target', AstHelper.Float),
+          AstHelper.buildArg('current', AstHelper.Float),
+        ],
+        undefined,
+        {isNative: true}
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('replaceGlobal', func);
+
+      // THEN
+      expect(code).toBe(``);
+    });
+
+    it('should format global function', () => {
+      // GIVEN
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'GetFact',
+        'Int32',
+        true,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('game', 'GameInstance'),
+          AstHelper.buildArg('factName', 'CName'),
+        ]
+      );
+
+      // WHEN
+      const code: string = fmt.formatSpecial('replaceGlobal', func);
+
+      // THEN
+      expect(code).toBe(`@replaceGlobal()
+public static func GetFact(game: GameInstance, factName: CName) -> Int32 {
+    let result: Int32;
+\u0020\u0020\u0020\u0020
+    return result;
+}`);
+    });
+  });
+});

--- a/src/shared/formatters/redscript.formatter.spec.ts
+++ b/src/shared/formatters/redscript.formatter.spec.ts
@@ -12,7 +12,6 @@ describe('RedscriptFormatter', () => {
     fmt = new RedscriptFormatter();
   });
 
-  /*
   describe('formatCall()', () => {
     it('should format global function', () => {
       // GIVEN
@@ -26,9 +25,9 @@ describe('RedscriptFormatter', () => {
       const code: string = fmt.formatCall(globalFn);
 
       // THEN
-      expect(code).toBe('local player -- ref<PlayerPuppet>\n' +
+      expect(code).toBe('let player: ref<PlayerPuppet>;\n' +
         '\n' +
-        'player = Game.GetPlayer()\n');
+        'player = GetPlayer();\n');
     });
 
     it('should format static function', () => {
@@ -46,10 +45,10 @@ describe('RedscriptFormatter', () => {
       const code: string = fmt.formatCall(staticFn, object);
 
       // THEN
-      expect(code).toBe('local other -- GameTime\n' +
-        'local isAfter -- Bool\n' +
+      expect(code).toBe('let other: GameTime;\n' +
+        'let isAfter: Bool;\n' +
         '\n' +
-        'isAfter = GameTime.IsAfter(other)\n');
+        'isAfter = GameTime.IsAfter(other);\n');
     });
 
     it('should format static function and ignore full name', () => {
@@ -60,7 +59,7 @@ describe('RedscriptFormatter', () => {
         AstHelper.Bool,
         true,
         RedVisibilityDef.public,
-        [AstHelper.buildArg('game', 'ScriptGameInstance')],
+        [AstHelper.buildArg('game', AstHelper.buildType('ScriptGameInstance', 'GameInstance'))],
         'gameVehicleSystem::IsPlayerInVehicle;GameInstance'
       );
 
@@ -68,10 +67,10 @@ describe('RedscriptFormatter', () => {
       const code: string = fmt.formatCall(staticFn, systemObj);
 
       // THEN
-      expect(code).toBe('local game -- ScriptGameInstance\n' +
-        'local isPlayerInVehicle -- Bool\n' +
+      expect(code).toBe('let game: GameInstance;\n' +
+        'let isPlayerInVehicle: Bool;\n' +
         '\n' +
-        'isPlayerInVehicle = VehicleSystem.IsPlayerInVehicle(game)\n');
+        'isPlayerInVehicle = VehicleSystem.IsPlayerInVehicle(game);\n');
     });
 
     it('should format member function', () => {
@@ -82,7 +81,7 @@ describe('RedscriptFormatter', () => {
         false,
         RedVisibilityDef.public,
         [
-          AstHelper.buildArg('targetID', 'entEntityID'),
+          AstHelper.buildArg('targetID', AstHelper.buildType('entEntityID', 'EntityID')),
           AstHelper.buildArg('duration', AstHelper.Float),
           AstHelper.buildArg('invert', AstHelper.Bool)
         ]
@@ -92,13 +91,13 @@ describe('RedscriptFormatter', () => {
       const code: string = fmt.formatCall(memberFn, vehicleObj);
 
       // THEN
-      expect(code).toBe('local vehicleobject -- VehicleObject\n' +
-        'local targetID -- entEntityID\n' +
-        'local duration -- Float\n' +
-        'local invert -- Bool\n' +
-        'local navPathToTarget -- Bool\n' +
+      expect(code).toBe('let vehicleobject: VehicleObject;\n' +
+        'let targetID: EntityID;\n' +
+        'let duration: Float;\n' +
+        'let invert: Bool;\n' +
+        'let navPathToTarget: Bool;\n' +
         '\n' +
-        'navPathToTarget = vehicleobject:HasNavPathToTarget(targetID, duration, invert)\n');
+        'navPathToTarget = vehicleobject.HasNavPathToTarget(targetID, duration, invert);\n');
     });
 
     it('should format member function and ignore full name', () => {
@@ -118,10 +117,10 @@ describe('RedscriptFormatter', () => {
       const code: string = fmt.formatCall(memberFn, vehicleObj);
 
       // THEN
-      expect(code).toBe('local vehicleobject -- VehicleObject\n' +
-        'local maxDelayOverride -- Float, optional\n' +
+      expect(code).toBe('let vehicleobject: VehicleObject;\n' +
+        'let maxDelayOverride: Float; // Optional\n' +
         '\n' +
-        'vehicleobject:TriggerExitBehavior(maxDelayOverride)\n');
+        'vehicleobject.TriggerExitBehavior(maxDelayOverride);\n');
     });
 
     it('should format global function with an alias', () => {
@@ -130,16 +129,21 @@ describe('RedscriptFormatter', () => {
       const globalFn: RedFunctionAst = AstHelper.buildFunction(
         'GetBlackboardSystem',
         AstHelper.buildRef('gameBlackboardSystem', 'BlackboardSystem'),
-        true
+        true,
+        RedVisibilityDef.public,
+        [
+          AstHelper.buildArg('self', AstHelper.buildType('ScriptGameInstance', 'GameInstance'))
+        ]
       );
 
       // WHEN
       const code: string = fmt.formatCall(globalFn, gameInstanceObj);
 
       // THEN
-      expect(code).toBe('local blackboardSystem -- ref<BlackboardSystem>\n' +
+      expect(code).toBe('let self: GameInstance;\n' +
+        'let blackboardSystem: ref<BlackboardSystem>;\n' +
         '\n' +
-        'blackboardSystem = Game.GetBlackboardSystem()\n');
+        'blackboardSystem = GameInstance.GetBlackboardSystem(self);\n');
     });
 
     it('should format member function without name conflicts', () => {
@@ -166,15 +170,14 @@ describe('RedscriptFormatter', () => {
       const code: string = fmt.formatCall(memberFn, vehicleComponentObj);
 
       // THEN
-      expect(code).toEqual('local gi -- GameInstance\n' +
-        'local vehicle -- wref<VehicleObject>\n' +
-        'local seats -- array<wref<VehicleSeat_Record>>\n' +
-        'local result -- Bool\n' +
+      expect(code).toEqual('let gi: GameInstance;\n' +
+        'let vehicle: wref<VehicleObject>;\n' +
+        'let seats: array<wref<VehicleSeat_Record>>;\n' +
+        'let result: Bool;\n' +
         '\n' +
-        'result = VehicleComponent.GetSeats(gi, vehicle, seats)\n');
+        'result = VehicleComponent.GetSeats(gi, vehicle, seats);\n');
     });
   });
-  */
 
   describe('formatPrototype()', () => {
     it('should format empty function', () => {

--- a/src/shared/formatters/redscript.formatter.ts
+++ b/src/shared/formatters/redscript.formatter.ts
@@ -34,10 +34,12 @@ export class RedscriptFormatter extends CodeFormatter {
     if (func.isStatic || !memberOf) {
       return undefined;
     }
+    let name: string = memberOf.aliasName ?? memberOf.name;
+
     return {
       prefix: 'let ',
-      name: memberOf.name.toLowerCase(),
-      suffix: `: ${memberOf.name};`
+      name: name.toLowerCase(),
+      suffix: `: ${name};`
     };
   }
 
@@ -45,7 +47,7 @@ export class RedscriptFormatter extends CodeFormatter {
     if (!func.returnType) {
       return undefined;
     }
-    const type: string = RedTypeAst.toString(func.returnType);
+    const type: string = RedTypeAst.toString(func.returnType, CodeSyntax.redscript);
 
     return {
       prefix: 'let ',
@@ -68,7 +70,9 @@ export class RedscriptFormatter extends CodeFormatter {
   }
 
   protected override formatMemberStaticCall(func: RedFunctionAst, memberOf: RedClassAst): string {
-    return `${memberOf.name}.${func.name}`;
+    let name: string = memberOf.aliasName ?? memberOf.name;
+
+    return `${name}.${func.name}`;
   }
 
   protected override formatMemberCall(selfVar: CodeVariableFormat, func: RedFunctionAst): string {

--- a/src/shared/formatters/redscript.formatter.ts
+++ b/src/shared/formatters/redscript.formatter.ts
@@ -3,11 +3,31 @@ import {RedClassAst} from "../red-ast/red-class.ast";
 import {RedTypeAst} from "../red-ast/red-type.ast";
 import {CodeFormatter, CodeVariableFormat} from "./formatter";
 import {RedArgumentAst} from "../red-ast/red-argument.ast";
+import {CodeSyntax} from "../services/settings.service";
+import {RedVisibilityDef} from "../red-ast/red-definitions.ast";
 
 export class RedscriptFormatter extends CodeFormatter {
 
   constructor() {
     super(true);
+  }
+
+  override formatPrototype(func: RedFunctionAst): string {
+    const args: string = this.formatPrototypeArguments(func);
+    const returnType: string = this.formatType(func.returnType);
+
+    return `${func.name}(${args}) -> ${returnType}`;
+  }
+
+  override formatSpecial(type: string, func: RedFunctionAst, memberOf?: RedClassAst): string {
+    if (type === 'wrapMethod') {
+      return this.formatWrapMethod(func, memberOf!);
+    } else if (type === 'replaceMethod') {
+      return this.formatReplaceMethod(func, memberOf!);
+    } else if (type === 'replaceGlobal') {
+      return this.formatReplaceGlobal(func);
+    }
+    return '';
   }
 
   protected override formatSelf(func: RedFunctionAst, memberOf?: RedClassAst): CodeVariableFormat | undefined {
@@ -36,7 +56,7 @@ export class RedscriptFormatter extends CodeFormatter {
 
   protected override formatArguments(func: RedFunctionAst, selfName?: string): CodeVariableFormat[] {
     return func.arguments.map((arg: RedArgumentAst) => {
-      const type: string = RedTypeAst.toString(arg.type);
+      const type: string = RedTypeAst.toString(arg.type, CodeSyntax.redscript);
       const optional: string = arg.isOptional ? ' // Optional' : '';
 
       return {
@@ -57,6 +77,112 @@ export class RedscriptFormatter extends CodeFormatter {
 
   protected override formatStaticCall(func: RedFunctionAst): string {
     return func.name;
+  }
+
+  private formatWrapMethod(func: RedFunctionAst, memberOf: RedClassAst): string {
+    if (func.isNative) {
+      return '';
+    }
+    const args: string = this.formatPrototypeArguments(func);
+    const flags: string = this.formatFlags(func);
+    const callArgs: string = this.formatCallArguments(func);
+    const returnType: string = this.formatType(func.returnType);
+    let code: string = '';
+
+    code += `@wrapMethod(${memberOf.aliasName ?? memberOf.name})\n`;
+    code += `${RedVisibilityDef[func.visibility]} ${flags}func ${func.name}(${args}) -> ${returnType} {\n`;
+    if (func.returnType) {
+      code += '    // Do stuff before\n';
+      code += `    let result: ${returnType} = wrappedMethod(${callArgs});\n`;
+      code += '    \n';
+      code += '    // Do stuff after\n';
+      code += '    return result;\n';
+    } else {
+      code += '    // Do stuff before\n';
+      code += `    wrappedMethod(${callArgs});\n`;
+      code += '    // Do stuff after\n';
+    }
+    code += '}';
+    return code;
+  }
+
+  private formatReplaceMethod(func: RedFunctionAst, memberOf: RedClassAst): string {
+    if (func.isNative) {
+      return '';
+    }
+    const args: string = this.formatPrototypeArguments(func);
+    const flags: string = this.formatFlags(func);
+    const returnType: string = this.formatType(func.returnType);
+    let code: string = '';
+
+    code += `@replaceMethod(${memberOf.aliasName ?? memberOf.name})\n`;
+    code += `${RedVisibilityDef[func.visibility]} ${flags}func ${func.name}(${args}) -> ${returnType} {\n`;
+    if (func.returnType) {
+      code += `    let result: ${returnType};\n`;
+      code += '    \n';
+      code += '    // Do stuff\n';
+      code += '    return result;\n';
+    } else {
+      code += '    // Do stuff\n';
+    }
+    code += '}';
+    return code;
+  }
+
+  private formatReplaceGlobal(func: RedFunctionAst): string {
+    if (func.isNative) {
+      return '';
+    }
+    const args: string = this.formatPrototypeArguments(func);
+    const flags: string = this.formatFlags(func);
+    const returnType: string = this.formatType(func.returnType);
+    let code: string = '';
+
+    code += `@replaceGlobal()\n`;
+    code += `${RedVisibilityDef[func.visibility]} ${flags}func ${func.name}(${args}) -> ${returnType} {\n`;
+    if (func.returnType) {
+      code += `    let result: ${returnType};\n`;
+      code += '    \n';
+      code += '    // Do stuff\n';
+      code += '    return result;\n';
+    } else {
+      code += '    // Do stuff\n';
+    }
+    code += '}';
+    return code;
+  }
+
+  private formatPrototypeArguments(func: RedFunctionAst): string {
+    return func.arguments.map((arg) => RedArgumentAst.toString(arg, CodeSyntax.redscript)).join(', ');
+  }
+
+  private formatCallArguments(func: RedFunctionAst): string {
+    return func.arguments.map((arg) => arg.name).join(', ');
+  }
+
+  private formatType(type?: RedTypeAst): string {
+    return type ? RedTypeAst.toString(type, CodeSyntax.redscript) : 'Void';
+  }
+
+  private formatFlags(func: RedFunctionAst): string {
+    let flags: string = '';
+
+    if (func.isFinal) {
+      flags += 'final ';
+    }
+    if (func.isStatic) {
+      flags += 'static ';
+    }
+    if (func.isConst) {
+      flags += 'const ';
+    }
+    if (func.isQuest) {
+      flags += 'quest ';
+    }
+    if (func.isCallback) {
+      flags += 'cb ';
+    }
+    return flags;
   }
 
 }

--- a/src/shared/formatters/redscript.formatter.ts
+++ b/src/shared/formatters/redscript.formatter.ts
@@ -92,15 +92,11 @@ export class RedscriptFormatter extends CodeFormatter {
     code += `@wrapMethod(${memberOf.aliasName ?? memberOf.name})\n`;
     code += `${RedVisibilityDef[func.visibility]} ${flags}func ${func.name}(${args}) -> ${returnType} {\n`;
     if (func.returnType) {
-      code += '    // Do stuff before\n';
       code += `    let result: ${returnType} = wrappedMethod(${callArgs});\n`;
       code += '    \n';
-      code += '    // Do stuff after\n';
       code += '    return result;\n';
     } else {
-      code += '    // Do stuff before\n';
       code += `    wrappedMethod(${callArgs});\n`;
-      code += '    // Do stuff after\n';
     }
     code += '}';
     return code;
@@ -120,10 +116,9 @@ export class RedscriptFormatter extends CodeFormatter {
     if (func.returnType) {
       code += `    let result: ${returnType};\n`;
       code += '    \n';
-      code += '    // Do stuff\n';
       code += '    return result;\n';
     } else {
-      code += '    // Do stuff\n';
+      code += '    \n';
     }
     code += '}';
     return code;
@@ -143,10 +138,9 @@ export class RedscriptFormatter extends CodeFormatter {
     if (func.returnType) {
       code += `    let result: ${returnType};\n`;
       code += '    \n';
-      code += '    // Do stuff\n';
       code += '    return result;\n';
     } else {
-      code += '    // Do stuff\n';
+      code += '    \n';
     }
     code += '}';
     return code;

--- a/src/shared/red-ast/red-argument.ast.ts
+++ b/src/shared/red-ast/red-argument.ast.ts
@@ -1,5 +1,6 @@
 import {RedPropertyJson} from "./red-property.ast";
 import {RedTypeAst} from "./red-type.ast";
+import {CodeSyntax} from "../services/settings.service";
 
 export interface RedArgumentAst {
   //readonly isConst: boolean;
@@ -10,6 +11,17 @@ export interface RedArgumentAst {
 }
 
 export class RedArgumentAst {
+  static toString(argument: RedArgumentAst, syntax?: CodeSyntax): string {
+    let flag: string = '';
+
+    if (argument.isOut) {
+      flag = 'out ';
+    } else if (argument.isOptional) {
+      flag = 'opt ';
+    }
+    return `${flag}${argument.name}: ${RedTypeAst.toString(argument.type, syntax)}`;
+  }
+
   static fromJson(json: RedPropertyJson): RedArgumentAst {
     const flags: number = json.c;
 

--- a/src/shared/services/code-formatter.service.ts
+++ b/src/shared/services/code-formatter.service.ts
@@ -23,10 +23,20 @@ export class CodeFormatterService {
     {syntax: CodeSyntax.cppRedLib, fmt: new CppRedLibFormatter()},
   ];
 
-  private syntax: CodeSyntax = CodeSyntax.lua;
+  private _syntax: CodeSyntax = CodeSyntax.lua;
 
   constructor(private readonly settingsService: SettingsService) {
     this.settingsService.clipboard$.subscribe(this.onClipboardChanged.bind(this));
+  }
+
+  public get syntax(): CodeSyntax {
+    return this._syntax;
+  }
+
+  formatPrototype(func: RedFunctionAst): string {
+    const formatter: CodeFormatter = this.getCodeFormatter();
+
+    return formatter.formatPrototype(func);
   }
 
   formatCall(func: RedFunctionAst, memberOf?: RedClassAst): string {
@@ -35,8 +45,14 @@ export class CodeFormatterService {
     return formatter.formatCall(func, memberOf);
   }
 
+  formatSpecial(type: string, func: RedFunctionAst, memberOf?: RedClassAst): string {
+    const formatter: CodeFormatter = this.getCodeFormatter();
+
+    return formatter.formatSpecial(type, func, memberOf);
+  }
+
   private getCodeFormatter(): CodeFormatter {
-    const item = this.formatters.find((item) => item.syntax === this.syntax);
+    const item = this.formatters.find((item) => item.syntax === this._syntax);
 
     if (!item) {
       throw Error();
@@ -45,6 +61,6 @@ export class CodeFormatterService {
   }
 
   private onClipboardChanged(syntax: CodeSyntax): void {
-    this.syntax = syntax;
+    this._syntax = syntax;
   }
 }

--- a/src/shared/services/code-formatter.service.ts
+++ b/src/shared/services/code-formatter.service.ts
@@ -29,10 +29,10 @@ export class CodeFormatterService {
     this.settingsService.clipboard$.subscribe(this.onClipboardChanged.bind(this));
   }
 
-  formatCode(func: RedFunctionAst, memberOf?: RedClassAst): string {
+  formatCall(func: RedFunctionAst, memberOf?: RedClassAst): string {
     const formatter: CodeFormatter = this.getCodeFormatter();
 
-    return formatter.formatCode(func, memberOf);
+    return formatter.formatCall(func, memberOf);
   }
 
   private getCodeFormatter(): CodeFormatter {

--- a/tests/ast.helper.ts
+++ b/tests/ast.helper.ts
@@ -77,7 +77,8 @@ export class AstHelper {
                        isStatic: boolean = false,
                        visibility: RedVisibilityDef = RedVisibilityDef.public,
                        args: RedArgumentAst[] = [],
-                       fullName?: string): RedFunctionAst {
+                       fullName?: string,
+                       flags?: any): RedFunctionAst {
     let type: RedTypeAst | undefined;
 
     if (typeof returnType === 'string') {
@@ -93,14 +94,14 @@ export class AstHelper {
       visibility: visibility ?? RedVisibilityDef.public,
       returnType: type,
       arguments: args ?? [],
-      isNative: false,
+      isNative: flags?.isNative ?? false,
       isStatic: isStatic ?? false,
-      isFinal: false,
-      isThreadSafe: false,
-      isCallback: false,
-      isConst: false,
-      isQuest: false,
-      isTimer: false
+      isFinal: flags?.isFinal ?? false,
+      isThreadSafe: flags?.isThreadSafe ?? false,
+      isCallback: flags?.isCallback ?? false,
+      isConst: flags?.isConst ?? false,
+      isQuest: flags?.isQuest ?? false,
+      isTimer: flags?.isTimer ?? false
     };
   }
 


### PR DESCRIPTION
Include features:
- copy prototype of function
- copy call of a function
- copy wrapMethod (Redscript)
- copy replaceMethod (Redscript)
- copy replaceGlobal (Redscript)
- copy Observe (Lua)
- copy ObserveAfter (Lua)
- copy Override (Lua)
- copy NewProxy (Lua)

Enable Redscript formatter with Clipboard syntax option.
Add unit tests.

Closes #88 