### PR TITLE
Copy code feature for red4ext-rs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#0F3142",
+    "titleBar.activeBackground": "#16445D",
+    "titleBar.activeForeground": "#F7FBFD"
+  },
+  "files.autoSave": "off",
+  "editor.formatOnSave": false
+}

--- a/src/shared/formatters/formatter.ts
+++ b/src/shared/formatters/formatter.ts
@@ -7,14 +7,13 @@ export interface CodeVariableFormat {
   readonly suffix: string;
 }
 
-export type ParenthesisRule = 'open-close' | 'close-only';
+export type ParenthesisRule = 'open-close' | 'close-only' | 'none';
 
 export abstract class CodeFormatter {
-
-  protected constructor(private readonly withSemiColon: boolean,
-                        private readonly withParenthesis: ParenthesisRule = 'open-close') {
-
-  }
+  protected constructor(
+    private readonly withSemiColon: boolean,
+    private readonly withParenthesis: ParenthesisRule = 'open-close'
+  ) {}
 
   /**
    * Format prototype of a function to code based on implementation syntax.
@@ -62,11 +61,16 @@ export abstract class CodeFormatter {
     } else if (func.isStatic) {
       code += this.formatStaticCall(func);
     }
-    if (this.withParenthesis !== 'close-only') {
+    if (
+      this.withParenthesis !== 'close-only' &&
+      this.withParenthesis !== 'none'
+    ) {
       code += '(';
     }
     code += argVars.map((argVar) => argVar.name).join(', ');
-    code += ')';
+    if (this.withParenthesis !== 'none') {
+      code += ')';
+    }
     if (this.withSemiColon) {
       code += ';';
     }

--- a/src/shared/formatters/red4ext-rs.formatter.spec.ts
+++ b/src/shared/formatters/red4ext-rs.formatter.spec.ts
@@ -1,0 +1,68 @@
+import { AstHelper } from '../../../tests/ast.helper';
+import { RedArgumentAst } from '../red-ast/red-argument.ast';
+import { RedVisibilityDef } from '../red-ast/red-definitions.ast';
+import { RedFunctionAst } from '../red-ast/red-function.ast';
+import { CodeFormatter } from './formatter';
+import { Red4extRsFormatter } from './red4ext-rs.formatter';
+
+describe('Red4extRsFormatter', () => {
+  let fmt: CodeFormatter;
+
+  beforeAll(() => {
+    fmt = new Red4extRsFormatter();
+  });
+
+  describe('formatCall()', () => {
+    it('should format global function', () => {
+      // GIVEN
+      const globalFn: RedFunctionAst = AstHelper.buildFunction(
+        'GetPlayer',
+        AstHelper.buildRef('PlayerPuppet'),
+        true,
+        RedVisibilityDef.public,
+        [
+          {
+            isOut: false,
+            isOptional: false,
+            name: 'game',
+            type: AstHelper.buildType('ScriptGameInstance', 'GameInstance'),
+          },
+        ]
+      );
+
+      // WHEN
+      const code: string = fmt.formatPrototype(globalFn);
+
+      // THEN
+      expect(code).toBe(
+        '#[redscript_global]\n' +
+          'pub fn get_player(game: GameInstance) -> MaybeUninitRef<PlayerPuppet>'
+      );
+    });
+  });
+  describe('formatPrototype()', () => {
+    it('should format empty function', () => {
+      // GIVEN
+      const func: RedFunctionAst = AstHelper.buildFunction('ArraySortInts');
+
+      // WHEN
+      const code: string = fmt.formatPrototype(func);
+
+      // THEN
+      expect(code).toBe('#[redscript_global]\npub fn array_sort_ints() -> ()');
+    });
+    it('should format function with return type', () => {
+      // GIVEN
+      const func: RedFunctionAst = AstHelper.buildFunction(
+        'CanLog',
+        AstHelper.Bool
+      );
+
+      // WHEN
+      const code: string = fmt.formatPrototype(func);
+
+      // THEN
+      expect(code).toBe('#[redscript_global]\npub fn can_log() -> bool');
+    });
+  });
+});

--- a/src/shared/formatters/red4ext-rs.formatter.spec.ts
+++ b/src/shared/formatters/red4ext-rs.formatter.spec.ts
@@ -1,5 +1,6 @@
 import { AstHelper } from '../../../tests/ast.helper';
 import { RedArgumentAst } from '../red-ast/red-argument.ast';
+import { RedClassAst } from '../red-ast/red-class.ast';
 import { RedVisibilityDef } from '../red-ast/red-definitions.ast';
 import { RedFunctionAst } from '../red-ast/red-function.ast';
 import { CodeFormatter } from './formatter';
@@ -63,6 +64,26 @@ describe('Red4extRsFormatter', () => {
 
       // THEN
       expect(code).toBe('#[redscript_global]\npub fn can_log() -> bool');
+    });
+
+    it('should format static function', () => {
+      // GIVEN
+      const object: RedClassAst = AstHelper.buildStruct('GameTime');
+      const staticFn: RedFunctionAst = AstHelper.buildFunction(
+        'IsAfter',
+        AstHelper.Bool,
+        true,
+        RedVisibilityDef.public,
+        [AstHelper.buildArg('other', 'GameTime')]
+      );
+
+      // WHEN
+      const code: string = fmt.formatCall(staticFn, object);
+
+      // THEN
+      expect(code).toBe(
+        '#[redscript_import]\nimpl GameTime {\n  pub fn is_after(other: GameTime) -> bool;\n}\n'
+      );
     });
   });
 });

--- a/src/shared/formatters/red4ext-rs.formatter.ts
+++ b/src/shared/formatters/red4ext-rs.formatter.ts
@@ -2,6 +2,7 @@ import { RedClassAst } from '../red-ast/red-class.ast';
 import { RedFunctionAst } from '../red-ast/red-function.ast';
 import { RedTypeAst } from '../red-ast/red-type.ast';
 import { CodeSyntax } from '../services/settings.service';
+import { camelToSnakeCase } from '../string';
 import { CodeFormatter, CodeVariableFormat } from './formatter';
 
 export class Red4extRsFormatter extends CodeFormatter {
@@ -15,7 +16,7 @@ export class Red4extRsFormatter extends CodeFormatter {
       ? '#[redscript_global(native)]'
       : '#[redscript_global]';
 
-    return `${annotation}\npub fn ${this.camelToSnakeCase(
+    return `${annotation}\npub fn ${camelToSnakeCase(
       func.name
     )}(${args}) -> ${returnType}`;
   }
@@ -57,9 +58,7 @@ export class Red4extRsFormatter extends CodeFormatter {
     const annotation: string = func.isNative ? `#[redscript(native)]\n` : '';
     return `#[redscript_import]
 impl ${memberOf.name} {
-  ${annotation}pub fn ${this.camelToSnakeCase(
-      func.name
-    )}(${args}) -> ${returnType};
+  ${annotation}pub fn ${camelToSnakeCase(func.name)}(${args}) -> ${returnType};
 }`;
   }
 
@@ -77,8 +76,7 @@ impl ${memberOf.name} {
   private formatPrototypeArguments(func: RedFunctionAst): string {
     return func.arguments
       .map(
-        (arg) =>
-          `${this.camelToSnakeCase(arg.name)}: ${this.formatType(arg.type)}`
+        (arg) => `${camelToSnakeCase(arg.name)}: ${this.formatType(arg.type)}`
       )
       .join(', ');
   }
@@ -93,11 +91,5 @@ impl ${memberOf.name} {
 
   private formatFlags(func: RedFunctionAst): string {
     return 'TODO';
-  }
-
-  private camelToSnakeCase(str: string) {
-    return str.replace(/[A-Z]/g, (letter, offset) =>
-      offset > 0 ? `_${letter.toLowerCase()}` : letter.toLowerCase()
-    );
   }
 }

--- a/src/shared/formatters/red4ext-rs.formatter.ts
+++ b/src/shared/formatters/red4ext-rs.formatter.ts
@@ -1,0 +1,95 @@
+import { RedClassAst } from '../red-ast/red-class.ast';
+import { RedFunctionAst } from '../red-ast/red-function.ast';
+import { RedTypeAst } from '../red-ast/red-type.ast';
+import { CodeSyntax } from '../services/settings.service';
+import { CodeFormatter, CodeVariableFormat } from './formatter';
+
+export class Red4extRsFormatter extends CodeFormatter {
+  constructor() {
+    super(true);
+  }
+  override formatPrototype(func: RedFunctionAst): string {
+    const args: string = this.formatPrototypeArguments(func);
+    const returnType: string = this.formatType(func.returnType);
+    const annotation: string = func.isNative
+      ? '#[redscript_global(native)]'
+      : '#[redscript_global]';
+
+    return `${annotation}\npub fn ${this.camelToSnakeCase(
+      func.name
+    )}(${args}) -> ${returnType}`;
+  }
+
+  override formatSpecial(
+    type: string,
+    func: RedFunctionAst,
+    memberOf?: RedClassAst
+  ): string {
+    return 'TODO';
+  }
+
+  protected override formatSelf(
+    func: RedFunctionAst,
+    memberOf?: RedClassAst
+  ): CodeVariableFormat | undefined {
+    return undefined;
+  }
+
+  protected override formatReturn(
+    func: RedFunctionAst
+  ): CodeVariableFormat | undefined {
+    return undefined;
+  }
+
+  protected override formatArguments(
+    func: RedFunctionAst,
+    selfName?: string
+  ): CodeVariableFormat[] {
+    return [];
+  }
+
+  protected override formatMemberStaticCall(
+    func: RedFunctionAst,
+    memberOf: RedClassAst
+  ): string {
+    return 'TODO';
+  }
+
+  protected override formatMemberCall(
+    selfVar: CodeVariableFormat,
+    func: RedFunctionAst
+  ): string {
+    return 'TODO';
+  }
+
+  protected override formatStaticCall(func: RedFunctionAst): string {
+    return 'TODO';
+  }
+
+  private formatPrototypeArguments(func: RedFunctionAst): string {
+    return func.arguments
+      .map(
+        (arg) =>
+          `${this.camelToSnakeCase(arg.name)}: ${this.formatType(arg.type)}`
+      )
+      .join(', ');
+  }
+
+  private formatCallArguments(func: RedFunctionAst): string {
+    return func.arguments.map((arg) => arg.name).join(', ');
+  }
+
+  private formatType(type?: RedTypeAst): string {
+    return type ? RedTypeAst.toString(type, CodeSyntax.rustRED4ext) : '()';
+  }
+
+  private formatFlags(func: RedFunctionAst): string {
+    return 'TODO';
+  }
+
+  private camelToSnakeCase(str: string) {
+    return str.replace(/[A-Z]/g, (letter, offset) =>
+      offset > 0 ? `_${letter.toLowerCase()}` : letter.toLowerCase()
+    );
+  }
+}

--- a/src/shared/formatters/red4ext-rs.formatter.ts
+++ b/src/shared/formatters/red4ext-rs.formatter.ts
@@ -6,7 +6,7 @@ import { CodeFormatter, CodeVariableFormat } from './formatter';
 
 export class Red4extRsFormatter extends CodeFormatter {
   constructor() {
-    super(true);
+    super(false, 'none');
   }
   override formatPrototype(func: RedFunctionAst): string {
     const args: string = this.formatPrototypeArguments(func);
@@ -52,7 +52,15 @@ export class Red4extRsFormatter extends CodeFormatter {
     func: RedFunctionAst,
     memberOf: RedClassAst
   ): string {
-    return 'TODO';
+    const args: string = this.formatPrototypeArguments(func);
+    const returnType: string = this.formatType(func.returnType);
+    const annotation: string = func.isNative ? `#[redscript(native)]\n` : '';
+    return `#[redscript_import]
+impl ${memberOf.name} {
+  ${annotation}pub fn ${this.camelToSnakeCase(
+      func.name
+    )}(${args}) -> ${returnType};
+}`;
   }
 
   protected override formatMemberCall(

--- a/src/shared/services/settings.service.ts
+++ b/src/shared/services/settings.service.ts
@@ -21,7 +21,8 @@ export enum CodeSyntax {
   redscript,
   lua,
   cppRED4ext,
-  cppRedLib
+  cppRedLib,
+  rustRED4ext,
 }
 
 @Injectable({

--- a/src/shared/string.spec.ts
+++ b/src/shared/string.spec.ts
@@ -1,4 +1,4 @@
-import {cyrb53} from "./string";
+import { camelToSnakeCase, cyrb53 } from './string';
 
 describe('cyrb53(string, seed = 0)', () => {
 
@@ -9,5 +9,14 @@ describe('cyrb53(string, seed = 0)', () => {
   it('should return hash code 23061388323667 with \'ScriptGameInstance\'', () => {
     expect(cyrb53('ScriptGameInstance')).toBe(23061388323667);
   });
+});
 
+describe('camelToSnakeCase(string)', () => {
+  it("should return array_sort_ints with 'ArraySortInts'", () => {
+    expect(camelToSnakeCase('ArraySortInts')).toBe('array_sort_ints');
+  });
+
+  it("should return is_after with 'IsAfter'", () => {
+    expect(camelToSnakeCase('IsAfter')).toBe('is_after');
+  });
 });

--- a/src/shared/string.ts
+++ b/src/shared/string.ts
@@ -13,3 +13,9 @@ export function cyrb53(str: string, seed: number = 0): number {
   h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
   return 4294967296 * (2097151 & h2) + (h1 >>> 0);
 }
+
+export function camelToSnakeCase(str: string): string {
+  return str.replace(/[A-Z]/g, (letter, offset) =>
+    offset > 0 ? `_${letter.toLowerCase()}` : letter.toLowerCase()
+  );
+}


### PR DESCRIPTION
Add `Copy call` and `Copy binding` feature for [red4ext-rs](https://github.com/jac3km4/red4ext-rs).

I'm gonna be quite slow on this PR since I have many things on the side, hence why I open it as a `Draft` first.
That also gives you the opportunity to review and request changes during development, if needed, too :)