### PR TITLE
Support documentation of global functions with GitBook

### DIFF
--- a/src/app/components/ndb-documentation/ndb-documentation.component.ts
+++ b/src/app/components/ndb-documentation/ndb-documentation.component.ts
@@ -71,20 +71,20 @@ export class NDBDocumentationComponent {
   showGitBook(): void {
     const path: string = this.getGitBookPath();
 
-    window.open(`https://wiki.redmodding.org/nativedb-documentation/classes/${path}`, '_blank');
+    window.open(`https://wiki.redmodding.org/nativedb-documentation/${path}`, '_blank');
   }
 
   editGitBook(): void {
     const path: string = this.getGitBookPath();
 
-    window.open(`https://app.gitbook.com/o/-MP5ijqI11FeeX7c8-N8/s/iEOlL96xX95sTRIvzobZ/classes/${path}`, '_blank');
+    window.open(`https://app.gitbook.com/o/-MP5ijqI11FeeX7c8-N8/s/iEOlL96xX95sTRIvzobZ/${path}`, '_blank');
   }
 
   private getGitBookPath(): string {
     if (!this.object) {
-      return '';
+      return `globals#${this.formatFragment()}`;
     }
-    let path: string = this.object.name.toLowerCase();
+    let path: string = `classes/${this.object.name.toLowerCase()}`;
 
     if (!this.method) {
       path = `${path}#description`;

--- a/src/app/components/spans/function-span/function-span.component.ts
+++ b/src/app/components/spans/function-span/function-span.component.ts
@@ -16,7 +16,7 @@ import {MatTooltipModule} from "@angular/material/tooltip";
 import {RouterLink} from "@angular/router";
 import {MatMenu, MatMenuItem, MatMenuTrigger} from "@angular/material/menu";
 import {MatDivider} from "@angular/material/divider";
-import {WikiClassDto, WikiFunctionDto} from "../../../../shared/dtos/wiki.dto";
+import {WikiClassDto, WikiFunctionDto, WikiGlobalDto} from "../../../../shared/dtos/wiki.dto";
 
 @Component({
   selector: 'function-span',
@@ -106,12 +106,18 @@ export class FunctionSpanComponent implements AfterViewInit {
   }
 
   @Input('documentation')
-  set _documentation(value: WikiClassDto | undefined) {
+  set _documentation(value: WikiClassDto | WikiFunctionDto | undefined) {
     if (!value) {
       this.documentation = undefined;
       return;
     }
-    this.documentation = value.functions.find((method) => method.id === this.node!.id);
+    if ('functions' in value) {
+      const wikiClass = value as WikiClassDto;
+
+      this.documentation = wikiClass.functions.find((method) => method.id === this.node!.id);
+    } else {
+      this.documentation = value as WikiGlobalDto;
+    }
   }
 
   /**

--- a/src/app/pages/function/function.component.html
+++ b/src/app/pages/function/function.component.html
@@ -1,12 +1,16 @@
-@if (function$ | async; as func) {
-  <ndb-title-bar [title]="func.name"
-                 [node]="func"
+@if (data$ | async; as data) {
+  <ndb-title-bar [title]="data.function.name"
+                 [node]="data.function"
                  [hideDocumentation]="true"
                  [hidden]="true">
     <mat-icon class="badge-function" svgIcon="function" matTooltip="function"></mat-icon>
   </ndb-title-bar>
 
-  <function-span [node]="func" [canCopy]="true" [canShare]="false"></function-span>
+  <function-span [node]="data.function"
+                 [documentation]="data.documentation"
+                 [canCopy]="true"
+                 [canDocument]="true"
+                 [canShare]="false" />
 } @else {
   <h1 class="stx stx-type">Loading...</h1>
   <div class="prototype">

--- a/src/app/pages/function/function.component.ts
+++ b/src/app/pages/function/function.component.ts
@@ -1,6 +1,6 @@
 import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {MatIconModule} from "@angular/material/icon";
-import {EMPTY, Observable} from "rxjs";
+import {combineLatest, EMPTY, filter, map, Observable} from "rxjs";
 import {RedDumpService} from "../../../shared/services/red-dump.service";
 import {AsyncPipe} from "@angular/common";
 import {FunctionSpanComponent} from "../../components/spans/function-span/function-span.component";
@@ -9,6 +9,13 @@ import {PageService} from "../../../shared/services/page.service";
 import {NDBTitleBarComponent} from "../../components/ndb-title-bar/ndb-title-bar.component";
 import {RecentVisitService} from "../../../shared/services/recent-visit.service";
 import {MatTooltip} from "@angular/material/tooltip";
+import {WikiService} from "../../../shared/services/wiki.service";
+import {WikiGlobalDto} from "../../../shared/dtos/wiki.dto";
+
+interface FunctionData {
+  readonly function: RedFunctionAst;
+  readonly documentation?: WikiGlobalDto;
+}
 
 @Component({
   selector: 'ndb-page-function',
@@ -26,9 +33,10 @@ import {MatTooltip} from "@angular/material/tooltip";
 })
 export class FunctionComponent {
 
-  function$: Observable<RedFunctionAst | undefined> = EMPTY;
+  data$: Observable<FunctionData | undefined> = EMPTY;
 
   constructor(private readonly dumpService: RedDumpService,
+              private readonly wikiService: WikiService,
               private readonly pageService: PageService,
               private readonly recentVisitService: RecentVisitService) {
   }
@@ -37,7 +45,17 @@ export class FunctionComponent {
   set id(id: string) {
     this.pageService.restoreScroll();
     this.recentVisitService.pushLastVisit(+id);
-    this.function$ = this.dumpService.getFunctionById(+id);
+    this.data$ = combineLatest([
+      this.dumpService.getFunctionById(+id),
+      this.wikiService.getGlobal(+id)
+    ]).pipe(
+      filter(([func]) => !!func),
+      map(([func, documentation]) => {
+        return <FunctionData>{
+          function: func,
+          documentation: documentation
+        }
+      }));
   }
 
 }

--- a/src/app/pages/functions/functions.component.html
+++ b/src/app/pages/functions/functions.component.html
@@ -9,8 +9,13 @@
     </div>
   </ndb-title-bar>
 
-  @for (func of data.functions; track func.fullName) {
-    <function-span [node]="func" [canCopy]="true" [canShare]="false"></function-span>
+  @for (func of data.functions; track func.func.fullName) {
+    <function-span [node]="func.func"
+                   [documentation]="func.documentation"
+                   [canCopy]="true"
+                   [canDocument]="true"
+                   [canShare]="false" />
+
     @if (data.isMobile && !$last) {
       <mat-divider></mat-divider>
     }

--- a/src/shared/clients/wiki.client.spec.ts
+++ b/src/shared/clients/wiki.client.spec.ts
@@ -91,4 +91,65 @@ Testing WikiClient with struct ScriptGameInstance.`,
     });
   });
 
+  describe('getGlobals()', () => {
+    let mockGetFileFrom: jest.SpyInstance;
+
+    beforeAll(() => {
+      mockGetFileFrom = jest.spyOn(wiki, 'getFileFrom' as any);
+    });
+
+    it('should throw WikiEncodingError when encoding is not \'base64\'', async () => {
+      // GIVEN
+      mockGetFileFrom.mockReturnValueOnce(of({encoding: 'binary'}));
+
+      // WHEN
+      const promise: Promise<WikiFileDto> = firstValueFrom(wiki.getGlobals());
+
+      // THEN
+      await expect(promise).rejects.toThrow(WikiEncodingError);
+    });
+
+    it('should emit WikiFileDto with decoded data and strip markdown of options', async () => {
+      // GIVEN
+      mockGetFileFrom.mockReturnValueOnce(of(<GitHubFileDto>{
+        encoding: 'base64',
+        content: 'LS0tCmxheW91dDoKICB0aXRsZToKICAgIHZpc2libGU6IHRydWUKICBkZXNj\n' +
+          'cmlwdGlvbjoKICAgIHZpc2libGU6IGZhbHNlCiAgdGFibGVPZkNvbnRlbnRz\n' +
+          'OgogICAgdmlzaWJsZTogdHJ1ZQogIG91dGxpbmU6CiAgICB2aXNpYmxlOiB0\n' +
+          'cnVlCiAgcGFnaW5hdGlvbjoKICAgIHZpc2libGU6IHRydWUKLS0tCgojIEdM\n' +
+          'T0JBTFMKCiMjIyMgR2V0R2FtZUluc3RhbmNlKCkgLT4gU2NyaXB0R2FtZUlu\n' +
+          'c3RhbmNlCgpXaGVuIFtDb2Rld2FyZV0oaHR0cHM6Ly9naXRodWIuY29tL3Bz\n' +
+          'aWJlcngvY3AyMDc3LWNvZGV3YXJlL3dpa2kpIGlzIGluc3RhbGxlZCwgeW91\n' +
+          'IGNhbiB1c2UgdGhpcyBmdW5jdGlvbiB3aXRob3V0IGlzc3Vlcy4gT3RoZXJ3\n' +
+          'aXNlLCB5b3UgbWF5IG5lZWQgdG8gZ2V0IFxbR2FtZUluc3RhbmNlXSB0aHJv\n' +
+          'dWdoIG90aGVyIGZ1bmN0aW9ucyBsaWtlIFxbR2FtZU9iamVjdC5HZXRHYW1l\n' +
+          'XSBmb3IgZXhhbXBsZS4KClRoaXMgZnVuY3Rpb24gd2lsbCBvbmx5IHdvcmsg\n' +
+          'd2hlbiB0aGUgZ2FtZSBlbmdpbmUgaXMgaW5pdGlhbGl6ZWQsIG1lYW5pbmcg\n' +
+          'YSBcW0dhbWVJbnN0YW5jZV0gZG8gZXhpc3RzLgo=\n',
+        sha: '<SHA>',
+        name: 'globals.md',
+        path: '<PATH>',
+      }));
+
+      // WHEN
+      const promise: Promise<WikiFileDto> = firstValueFrom(wiki.getGlobals());
+
+      // THEN
+      await expect(promise).resolves.toEqual(<WikiFileDto>{
+        sha: '<SHA>',
+        fileName: 'globals.md',
+        className: 'GLOBALS',
+        path: '<PATH>',
+        markdown: `# GLOBALS
+
+#### GetGameInstance() -> ScriptGameInstance
+
+When [Codeware](https://github.com/psiberx/cp2077-codeware/wiki) is installed, you can use this function without issues. Otherwise, you may need to get \\[GameInstance] through other functions like \\[GameObject.GetGame] for example.
+
+This function will only work when the game engine is initialized, meaning a \\[GameInstance] do exists.
+`,
+      });
+    });
+  });
+
 });

--- a/src/shared/clients/wiki.client.ts
+++ b/src/shared/clients/wiki.client.ts
@@ -49,6 +49,26 @@ export class WikiClient extends GitHubClient {
     );
   }
 
+  public getGlobals(): Observable<WikiFileDto> {
+    return this.getFileFrom('globals.md').pipe(
+      map((file: GitHubFileDto) => {
+        if (file.encoding !== 'base64') {
+          throw new WikiEncodingError(file.encoding);
+        }
+        let markdown: string = atob(file.content);
+
+        markdown = markdown.replaceAll(/^---(.*\n)*---\n\n/gm, '');
+        return {
+          sha: file.sha,
+          fileName: file.name,
+          className: 'GLOBALS',
+          path: file.path,
+          markdown: markdown
+        };
+      })
+    );
+  }
+
   private static getClassName(fileName: string): string {
     return fileName.substring(0, fileName.indexOf('.md'));
   }

--- a/src/shared/dtos/wiki.dto.ts
+++ b/src/shared/dtos/wiki.dto.ts
@@ -1,7 +1,7 @@
 export interface WikiFileEntryDto {
   readonly sha: string;
   readonly fileName: string;
-  readonly className: string;
+  readonly className: string | 'GLOBALS';
   readonly path: string;
 }
 
@@ -21,4 +21,8 @@ export interface WikiFunctionDto {
   readonly id: number;
   readonly name: string;
   readonly comment: string;
+}
+
+export interface WikiGlobalDto extends WikiFunctionDto {
+  readonly sha: string;
 }

--- a/src/shared/parsers/wiki.parser.ts
+++ b/src/shared/parsers/wiki.parser.ts
@@ -26,8 +26,12 @@ export class WikiParser {
     const headerDescription: Tokens.Heading | undefined = stream.nextHeading(2, true);
     const comment: string = this.parseDescription(stream, headerDescription);
     const headerFunctions: Tokens.Heading | undefined = stream.nextHeading(2, true);
-    const functions: WikiFunctionDto[] = this.parseFunctions(stream, headerFunctions);
+    let functions: WikiFunctionDto[] = [];
 
+    if (this.isFunctions(headerFunctions)) {
+      stream.nextHeading(2);
+      functions = this.parseFunctions(stream);
+    }
     if (!headerDescription && !headerFunctions) {
       throw new WikiParserError(name, WikiParserErrorCode.noContent);
     }
@@ -62,11 +66,7 @@ export class WikiParser {
     return description.trim();
   }
 
-  private parseFunctions(stream: WikiTokenStream, header?: Tokens.Heading): WikiFunctionDto[] {
-    if (!this.isFunctions(header)) {
-      return [];
-    }
-    stream.nextHeading(2);
+  private parseFunctions(stream: WikiTokenStream): WikiFunctionDto[] {
     const functions: WikiFunctionDto[] = [];
 
     while (stream.hasNext()) {

--- a/src/shared/parsers/wiki.parser.ts
+++ b/src/shared/parsers/wiki.parser.ts
@@ -1,6 +1,6 @@
 import {Injectable} from "@angular/core";
 import {marked, Token, Tokens, TokensList} from "marked";
-import {WikiClassDto, WikiFileDto, WikiFunctionDto} from "../dtos/wiki.dto";
+import {WikiClassDto, WikiFileDto, WikiFunctionDto, WikiGlobalDto} from "../dtos/wiki.dto";
 import {cyrb53} from "../string";
 import {RedTypeAst} from "../red-ast/red-type.ast";
 import ListItem = Tokens.ListItem;
@@ -42,6 +42,24 @@ export class WikiParser {
       comment: comment,
       functions: functions
     };
+  }
+
+  public parseGlobals(file: WikiFileDto): WikiGlobalDto[] {
+    const tokens: TokensList = marked.lexer(file.markdown, {gfm: true});
+    const stream: WikiTokenStream = new WikiTokenStream(tokens);
+    const headerTitle: Tokens.Heading | undefined = stream.nextHeading(1);
+
+    if (!headerTitle) {
+      throw new WikiParserError('GLOBALS', WikiParserErrorCode.noTitle);
+    }
+    const functions: WikiFunctionDto[] = this.parseFunctions(stream);
+
+    return functions.map((func) => {
+      return {
+        ...func,
+        sha: file.sha
+      };
+    });
   }
 
   private parseDescription(stream: WikiTokenStream, header?: Tokens.Heading): string {

--- a/src/shared/repositories/wiki-classes.repository.ts
+++ b/src/shared/repositories/wiki-classes.repository.ts
@@ -1,0 +1,26 @@
+import {Injectable} from "@angular/core";
+import {CrudRepository} from "./crud.repository";
+import {WikiClassDto} from "../dtos/wiki.dto";
+import {Table} from "dexie";
+import {Observable} from "rxjs";
+import {fromPromise} from "rxjs/internal/observable/innerFrom";
+import {WikiDB} from "./wiki.database";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class WikiClassesRepository extends CrudRepository<WikiClassDto> {
+
+  constructor(db: WikiDB) {
+    super(db);
+  }
+
+  protected override get table(): Table<WikiClassDto, number, WikiClassDto> {
+    return this.db.classes;
+  }
+
+  public findByName(name: string): Observable<WikiClassDto | undefined> {
+    return fromPromise(this.table.where('name').equalsIgnoreCase(name).first());
+  }
+
+}

--- a/src/shared/repositories/wiki-globals.repository.ts
+++ b/src/shared/repositories/wiki-globals.repository.ts
@@ -1,6 +1,6 @@
 import {Injectable} from "@angular/core";
 import {CrudRepository} from "./crud.repository";
-import {WikiClassDto} from "../dtos/wiki.dto";
+import {WikiGlobalDto} from "../dtos/wiki.dto";
 import {Table} from "dexie";
 import {Observable} from "rxjs";
 import {fromPromise} from "rxjs/internal/observable/innerFrom";
@@ -9,17 +9,17 @@ import {WikiDB} from "./wiki.database";
 @Injectable({
   providedIn: 'root'
 })
-export class WikiRepository extends CrudRepository<WikiClassDto> {
+export class WikiGlobalsRepository extends CrudRepository<WikiGlobalDto> {
 
   constructor(db: WikiDB) {
     super(db);
   }
 
-  protected override get table(): Table<WikiClassDto, number, WikiClassDto> {
-    return this.db.classes;
+  protected override get table(): Table<WikiGlobalDto, number, WikiGlobalDto> {
+    return this.db.globals;
   }
 
-  public findByName(name: string): Observable<WikiClassDto | undefined> {
+  public findByName(name: string): Observable<WikiGlobalDto | undefined> {
     return fromPromise(this.table.where('name').equalsIgnoreCase(name).first());
   }
 

--- a/src/shared/repositories/wiki.database.ts
+++ b/src/shared/repositories/wiki.database.ts
@@ -1,5 +1,5 @@
 import Dexie, {Table} from "dexie";
-import {WikiClassDto} from "../dtos/wiki.dto";
+import {WikiClassDto, WikiGlobalDto} from "../dtos/wiki.dto";
 
 export interface Entity {
   id?: number;
@@ -8,11 +8,16 @@ export interface Entity {
 export class WikiDB extends Dexie {
 
   classes!: Table<WikiClassDto, number>;
+  globals!: Table<WikiGlobalDto, number>;
 
   constructor() {
     super('ndb-wiki');
     this.version(1).stores({
       classes: '&id, &name'
+    });
+    this.version(2).stores({
+      classes: '&id, &name',
+      globals: '&id, &name'
     });
   }
 

--- a/src/shared/services/wiki.service.ts
+++ b/src/shared/services/wiki.service.ts
@@ -92,7 +92,9 @@ export class WikiService {
       }),
       map((globals: (WikiGlobalDto | undefined)[]) => {
         return globals.filter((wikiGlobal) => !!wikiGlobal) as WikiGlobalDto[];
-      })
+      }),
+      catchError(this.showError.bind(this)),
+      map((globals?: WikiGlobalDto[]) => globals ?? [])
     );
   }
 


### PR DESCRIPTION
# Support documentation of global functions with GitBook

- request and parse Markdown from GitBook repository.
- cache globals using IndexedDB storage.
- invalidate cache after 10 min.
- show global function documentation in `<ndb-functions>` and `<ndb-function>` pages.
- update linking of GitBook to show/edit a global function's documentation.

Closes #204 