### PR TITLE
Show parent members of a class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "marked": "^15.0.0",
         "rxjs": "~7.8.1",
         "tslib": "^2.8.1",
+        "uuid": "^11.0.3",
         "zone.js": "^0.14.10"
       },
       "devDependencies": {
@@ -17577,6 +17578,17 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/socks": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
@@ -18793,14 +18805,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
-      "peer": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "marked": "^15.0.0",
     "rxjs": "~7.8.1",
     "tslib": "^2.8.1",
+    "uuid": "^11.0.3",
     "zone.js": "^0.14.10"
   },
   "devDependencies": {

--- a/src/app/pages/object/object.component.html
+++ b/src/app/pages/object/object.component.html
@@ -42,11 +42,28 @@
                     [disableRipple]="true">{{data.parents.length}}</mat-chip>
         </div>
 
+        <div actions>
+          <mat-slide-toggle
+            color="primary"
+            (change)="onShowMembersToggled($event, data.parents)"
+            [formControl]="showMembers">
+            {{showMembers.value ? 'Show' : 'Hide'}} members of all parents
+          </mat-slide-toggle>
+        </div>
+
         @for (parent of data.parents; track parent.id) {
           <div class="inheritance stx">
             <div class="align" [style.width]="data.align"></div>
+
+            <mat-icon class="btn"
+                      [class.disabled]="parent.isEmpty"
+                      (click)="toggleMembers(parent, data.parents)">
+              {{areMembersVisible(parent) ? 'check_box' : 'check_box_outline_blank'}}
+            </mat-icon>
+
             <mat-icon>subdirectory_arrow_right</mat-icon>
-            <type-span [node]="parent" [isEmpty]="data.highlightEmpty && parent.isEmpty"></type-span>
+
+            <type-span [node]="parent" [isEmpty]="data.highlightEmpty && parent.isEmpty" />
           </div>
         }
       </ndb-accordion-item>
@@ -64,7 +81,10 @@
         @for (child of data.children; track child.id) {
           <div class="inheritance stx">
             <div class="align" [style.width]="data.align"></div>
+            <mat-icon></mat-icon>
+
             <mat-icon>subdirectory_arrow_left</mat-icon>
+
             <type-span [node]="child" [isEmpty]="data.highlightEmpty && child.isEmpty"></type-span>
           </div>
         }
@@ -144,12 +164,12 @@
         </div>
 
         <!-- NOTE: tracking with id will crash webapp when filtering per badge several times. -->
-        @for (func of data.functions; track func.fullName) {
+        @for (func of data.functions; track func.function.fullName) {
           <function-span ndbHighlight
-                         [id]="cyrb53(func.name)"
-                         [node]="func"
-                         [memberOf]="data.object"
-                         [documentation]="data.documentation"
+                         [id]="cyrb53(func.function.name)"
+                         [node]="func.function"
+                         [memberOf]="func.memberOf"
+                         [documentation]="func.documentation"
                          [canCopy]="true"
                          [canDocument]="data.canDocument"
                          [badges]="data.badges"></function-span>

--- a/src/app/pages/object/object.component.scss
+++ b/src/app/pages/object/object.component.scss
@@ -56,6 +56,12 @@
       height: 18px;
       font-size: 18px;
       margin-right: 12px;
+
+      &.btn {
+        &:not(.disabled) {
+          cursor: pointer;
+        }
+      }
     }
 
     @media (max-width: 1025px) {

--- a/src/shared/services/red-dump.worker.ts
+++ b/src/shared/services/red-dump.worker.ts
@@ -105,20 +105,20 @@ async function load(port?: MessagePort): Promise<void> {
   isReady = true;
 }
 
-function onLoadInheritance(id: number, port?: MessagePort): void {
-  const object: RedClassAst | undefined = data.objects.find((object) => object.id === id);
+function onLoadInheritance(request: {token: string, id: number}, port?: MessagePort): void {
+  const object: RedClassAst | undefined = data.objects.find((object) => object.id === request.id);
 
   if (!object) {
     return;
   }
   if (object.isInheritanceLoaded) {
-    send(NDBCommand.rd_load_inheritance, port, [object.id, object.parents, object.children]);
+    send(NDBCommand.rd_load_inheritance, port, [request.token, object.id, object.parents, object.children]);
     return;
   }
   loadParents(data.objects, object);
   loadChildren(data.objects, object);
   object.isInheritanceLoaded = true;
-  send(NDBCommand.rd_load_inheritance, port, [object.id, object.parents, object.children]);
+  send(NDBCommand.rd_load_inheritance, port, [request.token, object.id, object.parents, object.children]);
 }
 
 function send(command: NDBCommand, port?: MessagePort, data?: any): void {

--- a/src/shared/services/search.service.ts
+++ b/src/shared/services/search.service.ts
@@ -90,22 +90,25 @@ export class SearchService {
     }
   }
 
-  public static filterFunctions(functions: RedFunctionAst[], request: SearchRequest): RedFunctionAst[] {
+  public static filterFunctions<T>(functions: T[],
+                                   request: SearchRequest,
+                                   key?: (data: T) => RedFunctionAst): T[] {
     const query: string = request.query.toLowerCase();
     const words: string[] = query.split(' ');
     const rule: RegExp | undefined = SearchService.createRule(query);
 
+    key ??= (data) => data as RedFunctionAst;
     if (request.filter === FilterBy.usage) {
       if (rule) {
-        return functions.filter((func) => RedFunctionAst.testByUsage(func, rule));
+        return functions.filter((func) => RedFunctionAst.testByUsage(key(func), rule));
       } else {
-        return functions.filter((func) => RedFunctionAst.filterByUsage(func, words));
+        return functions.filter((func) => RedFunctionAst.filterByUsage(key(func), words));
       }
     }
     if (rule) {
-      return functions.filter((func) => RedNodeAst.testName(func, rule));
+      return functions.filter((func) => RedNodeAst.testName(key(func), rule));
     } else {
-      return functions.filter((func) => RedNodeAst.hasName(func, words));
+      return functions.filter((func) => RedNodeAst.hasName(key(func), words));
     }
   }
 

--- a/src/styles/mat/_icon.scss
+++ b/src/styles/mat/_icon.scss
@@ -1,6 +1,8 @@
 @use 'sass:map';
+@use 'sass:color';
 
 @mixin icon-theme($theme) {
+  $primary: map.get($theme, primary);
   $badges: map.get($theme, 'badges');
 
   mat-icon {
@@ -23,6 +25,15 @@
 
       &function {
         color: map.get($badges, 'function');
+      }
+    }
+
+    &.btn {
+      color: map.get($primary, 500);
+
+      &[disabled],
+      &.disabled {
+        color: color.scale(map.get($primary, 500), $saturation: -50%, $lightness: -50%);
       }
     }
   }


### PR DESCRIPTION
# Show parent members of a class

- add checkbox per parent to show/hide its properties/functions.
- add toggle option to show/hide members of all parents.
- ignore empty parents (no properties nor functions).
- search/filter features are seamlessly working with parent members.

Closes #206