### PR TITLE
feat: show/hide members of parents by default

### DIFF
--- a/src/app/pages/object/object.component.ts
+++ b/src/app/pages/object/object.component.ts
@@ -8,7 +8,7 @@ import {NDBAccordionItemComponent} from "../../components/ndb-accordion-item/ndb
 import {TypeSpanComponent} from "../../components/spans/type-span/type-span.component";
 import {
   BehaviorSubject,
-  combineLatest,
+  combineLatest, combineLatestWith,
   delay,
   EMPTY,
   map,
@@ -253,6 +253,17 @@ export class ObjectComponent implements AfterViewInit {
     this.settingsService.showDocumentation$
       .pipe(take(1), takeUntilDestroyed(this.dr))
       .subscribe((show) => this.showDocumentationSubject.next(show));
+
+    this.settingsService.showMembers$
+      .pipe(
+        take(1),
+        takeUntilDestroyed(this.dr),
+        combineLatestWith(object$),
+      )
+      .subscribe(([show, object]) => {
+        this.showMembers.setValue(show, {emitEvent: false});
+        this.onShowMembersToggled(<any>{checked: show}, object.parents);
+      });
 
     this.data$ = combineLatest([
       object$,

--- a/src/app/pages/settings/settings.component.html
+++ b/src/app/pages/settings/settings.component.html
@@ -58,6 +58,18 @@
 
 <div class="setting">
   <p>
+    Show / hide members of parents by default.
+  </p>
+
+  <mat-slide-toggle color="primary" [formControl]="showMembers">
+    {{showMembers.value ? "Show" : "Hide"}}
+  </mat-slide-toggle>
+</div>
+
+<mat-divider></mat-divider>
+
+<div class="setting">
+  <p>
     Highlight empty classes and structs when they have no properties nor functions.
   </p>
 

--- a/src/app/pages/settings/settings.component.ts
+++ b/src/app/pages/settings/settings.component.ts
@@ -45,6 +45,7 @@ export class SettingsComponent implements OnInit {
   readonly scriptOnly: FormControl<boolean | null> = new FormControl(false);
   readonly scrollBehavior: FormControl<PageScrollBehavior | null> = new FormControl('smooth');
   readonly showDocumentation: FormControl<boolean | null> = new FormControl(true);
+  readonly showMembers: FormControl<boolean | null> = new FormControl(false);
   readonly highlightEmptyObject: FormControl<boolean | null> = new FormControl(true);
   readonly showEmptyAccordion: FormControl<boolean | null> = new FormControl(false);
   readonly mergeObject: FormControl<boolean | null> = new FormControl(false);
@@ -65,6 +66,7 @@ export class SettingsComponent implements OnInit {
     this.scriptOnly.valueChanges.pipe(takeUntilDestroyed(this.dr)).subscribe(this.onScriptOnlyChanged.bind(this));
     this.scrollBehavior.valueChanges.pipe(takeUntilDestroyed(this.dr)).subscribe(this.onScrollBehaviorChanged.bind(this));
     this.showDocumentation.valueChanges.pipe(takeUntilDestroyed(this.dr)).subscribe(this.onShowDocumentationChanged.bind(this));
+    this.showMembers.valueChanges.pipe(takeUntilDestroyed(this.dr)).subscribe(this.onShowMembersChanged.bind(this));
     this.highlightEmptyObject.valueChanges.pipe(takeUntilDestroyed(this.dr)).subscribe(this.onHighlightEmptyObjectChanged.bind(this));
     this.showEmptyAccordion.valueChanges.pipe(takeUntilDestroyed(this.dr)).subscribe(this.onShowEmptyAccordionChanged.bind(this));
     this.mergeObject.valueChanges.pipe(takeUntilDestroyed(this.dr)).subscribe(this.onMergeObjectChanged.bind(this));
@@ -91,6 +93,13 @@ export class SettingsComponent implements OnInit {
       return;
     }
     this.settingsService.updateScrollBehavior(behavior);
+  }
+
+  private onShowMembersChanged(state: boolean | null): void {
+    if (state === null) {
+      return;
+    }
+    this.settingsService.updateShowMembers(state);
   }
 
   private onShowDocumentationChanged(state: boolean | null): void {
@@ -140,6 +149,7 @@ export class SettingsComponent implements OnInit {
     this.scriptOnly.setValue(settings.scriptOnly, {emitEvent: false});
     this.scrollBehavior.setValue(settings.scrollBehavior, {emitEvent: false});
     this.showDocumentation.setValue(settings.showDocumentation, {emitEvent: false});
+    this.showMembers.setValue(settings.showMembers, {emitEvent: false});
     this.highlightEmptyObject.setValue(settings.highlightEmptyObject, {emitEvent: false});
     this.showEmptyAccordion.setValue(settings.showEmptyAccordion, {emitEvent: false});
     this.mergeObject.setValue(settings.mergeObject, {emitEvent: false});

--- a/src/shared/services/settings.service.ts
+++ b/src/shared/services/settings.service.ts
@@ -7,6 +7,7 @@ export interface Settings {
   readonly scriptOnly: boolean;
   readonly scrollBehavior: PageScrollBehavior;
   readonly showDocumentation: boolean;
+  readonly showMembers: boolean;
   readonly highlightEmptyObject: boolean;
   readonly showEmptyAccordion: boolean;
   readonly mergeObject: boolean;
@@ -34,6 +35,7 @@ export class SettingsService {
   private readonly scriptOnlySubject: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   private readonly scrollBehaviorSubject: BehaviorSubject<PageScrollBehavior> = new BehaviorSubject<PageScrollBehavior>('smooth');
   private readonly showDocumentationSubject: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
+  private readonly showMembersSubject: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   private readonly highlightEmptyObjectSubject: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
   private readonly showEmptyAccordionSubject: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   private readonly mergeObjectSubject: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
@@ -68,6 +70,11 @@ export class SettingsService {
    * Whether documented properties/functions should be visible?
    */
   readonly showDocumentation$: Observable<boolean> = this.showDocumentationSubject.asObservable();
+
+  /**
+   * Whether members of parents should be visible?
+   */
+  readonly showMembers$: Observable<boolean> = this.showMembersSubject.asObservable();
 
   /**
    * Whether empty class/struct should be highlighted?
@@ -110,6 +117,7 @@ export class SettingsService {
     const scriptOnly: boolean = (localStorage.getItem('script-only') ?? 'false') === 'true';
     const scrollBehavior: PageScrollBehavior = (localStorage.getItem('scroll-behavior') ?? 'smooth') as PageScrollBehavior;
     const showDocumentation: boolean = (localStorage.getItem('show-documentation') ?? 'true') === 'true';
+    const showMembers: boolean = (localStorage.getItem('show-members') ?? 'false') === 'true';
     const highlightEmptyObject: boolean = (localStorage.getItem('highlight-empty-object') ?? 'true') === 'true';
     const showEmptyAccordion: boolean = (localStorage.getItem('show-empty-accordion') ?? 'false') === 'true';
     const mergeObject: boolean = (localStorage.getItem('merge-object') ?? 'true') === 'true';
@@ -122,6 +130,7 @@ export class SettingsService {
     this.scriptOnlySubject.next(scriptOnly);
     this.scrollBehaviorSubject.next(scrollBehavior);
     this.showDocumentationSubject.next(showDocumentation);
+    this.showMembersSubject.next(showMembers);
     this.highlightEmptyObjectSubject.next(highlightEmptyObject);
     this.showEmptyAccordionSubject.next(showEmptyAccordion);
     this.mergeObjectSubject.next(mergeObject);
@@ -137,6 +146,7 @@ export class SettingsService {
       this.scriptOnly$,
       this.scrollBehavior$,
       this.showDocumentation$,
+      this.showMembers$,
       this.highlightEmptyObject$,
       this.showEmptyAccordion$,
       this.mergeObject$,
@@ -151,6 +161,7 @@ export class SettingsService {
                scriptOnly,
                scrollBehavior,
                showDocumentation,
+               showMembers,
                highlightEmptyObject,
                showEmptyAccordion,
                mergeObject,
@@ -164,6 +175,7 @@ export class SettingsService {
             scriptOnly: scriptOnly,
             scrollBehavior: scrollBehavior,
             showDocumentation: showDocumentation,
+            showMembers: showMembers,
             highlightEmptyObject: highlightEmptyObject,
             showEmptyAccordion: showEmptyAccordion,
             mergeObject: mergeObject,
@@ -202,6 +214,11 @@ export class SettingsService {
   updateShowDocumentation(state: boolean): void {
     localStorage.setItem('show-documentation', `${state}`);
     this.showDocumentationSubject.next(state);
+  }
+
+  updateShowMembers(state: boolean): void {
+    localStorage.setItem('show-members', `${state}`);
+    this.showMembersSubject.next(state);
   }
 
   updateHighlightEmptyObject(state: boolean): void {


### PR DESCRIPTION
- add option in page Settings, default to Hide.
- show/hide members of parents based on option when loading a class.

Closes #216