### PR TITLE
feat: change document title based on the visited definition

### DIFF
--- a/src/app/pages/bitfield/bitfield.component.ts
+++ b/src/app/pages/bitfield/bitfield.component.ts
@@ -62,6 +62,9 @@ export class BitfieldComponent {
           name = node!.aliasName;
           altName = node!.name;
         }
+
+        this.pageService.updateTitle(`NDB · ${name}`);
+
         return <BitfieldData>{
           node: node,
           name: name,

--- a/src/app/pages/bookmarks/bookmarks.component.ts
+++ b/src/app/pages/bookmarks/bookmarks.component.ts
@@ -8,6 +8,7 @@ import {MatIconModule} from "@angular/material/icon";
 import {TypeSpanComponent} from "../../components/spans/type-span/type-span.component";
 import {MatDividerModule} from "@angular/material/divider";
 import {MatTooltipModule} from "@angular/material/tooltip";
+import {PageService} from "../../../shared/services/page.service";
 
 interface BookmarkItem {
   readonly node: RedNodeAst;
@@ -33,10 +34,13 @@ export class BookmarksComponent implements OnInit {
   bookmarks$: Observable<BookmarkItem[]> = of([]);
 
   constructor(private readonly dumpService: RedDumpService,
+              private readonly pageService: PageService,
               private readonly bookmarkService: BookmarkService) {
   }
 
   ngOnInit(): void {
+    this.pageService.updateTitle(`NativeDB`);
+
     const bookmarks: number[] = this.bookmarkService.getAll();
     const bookmarks$ = bookmarks.map((id) => this.dumpService.getById(id));
 

--- a/src/app/pages/enum/enum.component.ts
+++ b/src/app/pages/enum/enum.component.ts
@@ -62,6 +62,9 @@ export class EnumComponent {
           name = node!.aliasName;
           altName = node!.name;
         }
+
+        this.pageService.updateTitle(`NDB · ${name}`);
+
         return <EnumData>{
           node: node,
           name: name,

--- a/src/app/pages/function/function.component.ts
+++ b/src/app/pages/function/function.component.ts
@@ -50,6 +50,10 @@ export class FunctionComponent {
     ]).pipe(
       filter(([func]) => !!func),
       map(([func, documentation]) => {
+        if (func) {
+          this.pageService.updateTitle(`NDB · ${func.fullName}`);
+        }
+
         return <FunctionData>{
           function: func,
           documentation: documentation

--- a/src/app/pages/functions/functions.component.ts
+++ b/src/app/pages/functions/functions.component.ts
@@ -15,6 +15,7 @@ import {SettingsService} from "../../../shared/services/settings.service";
 import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 import {WikiService} from "../../../shared/services/wiki.service";
 import {WikiGlobalDto} from "../../../shared/dtos/wiki.dto";
+import {PageService} from "../../../shared/services/page.service";
 
 interface FunctionData {
   readonly func: RedFunctionAst;
@@ -71,6 +72,7 @@ export class FunctionsComponent {
   constructor(private readonly dumpService: RedDumpService,
               private readonly wikiService: WikiService,
               private readonly settingsService: SettingsService,
+              private readonly pageService: PageService,
               private readonly responsiveService: ResponsiveService,
               private readonly dr: DestroyRef) {
     this.data$ = combineLatest([
@@ -96,6 +98,8 @@ export class FunctionsComponent {
     this.ignoreDuplicate.valueChanges.pipe(
       takeUntilDestroyed(this.dr)
     ).subscribe(this.onIgnoreDuplicateUpdated.bind(this));
+
+    this.pageService.updateTitle('NDB · Global functions');
   }
 
   private onIgnoreDuplicate(ignore: boolean) {

--- a/src/app/pages/object/object.component.ts
+++ b/src/app/pages/object/object.component.ts
@@ -595,10 +595,14 @@ export class ObjectComponent implements AfterViewInit {
       name = object.aliasName;
       altName = object.name;
     }
+
     of(true).pipe(
       delay(1),
       takeUntilDestroyed(this.dr)
     ).subscribe(this.onScrollToFragment.bind(this));
+
+    this.pageService.updateTitle(`NDB · ${name}`);
+
     return <ObjectData>{
       object: object,
       name: name,

--- a/src/app/pages/readme/readme.component.ts
+++ b/src/app/pages/readme/readme.component.ts
@@ -43,6 +43,7 @@ export class ReadmeComponent implements OnInit {
 
   ngOnInit(): void {
     this.pageService.restoreScroll();
+    this.pageService.updateTitle('NativeDB');
   }
 
   private getGameInstance(): OperatorFunction<RedFunctionAst[], RedFunctionAst | undefined> {

--- a/src/app/pages/recent-visits/recent-visits.component.ts
+++ b/src/app/pages/recent-visits/recent-visits.component.ts
@@ -9,6 +9,7 @@ import {RecentVisitItem, RecentVisitService} from "../../../shared/services/rece
 import {MatButtonModule} from "@angular/material/button";
 import {MatDividerModule} from "@angular/material/divider";
 import {MatTooltipModule} from "@angular/material/tooltip";
+import {PageService} from "../../../shared/services/page.service";
 
 interface RecentVisitData {
   readonly node: RedNodeAst;
@@ -36,10 +37,13 @@ export class RecentVisitsComponent implements OnInit {
   cannotClearAll$: Observable<boolean> = of(true);
 
   constructor(private readonly dumpService: RedDumpService,
+              private readonly pageService: PageService,
               private readonly recentVisitService: RecentVisitService) {
   }
 
   ngOnInit(): void {
+    this.pageService.updateTitle('NativeDB');
+
     const items: RecentVisitItem[] = this.recentVisitService.getAll();
 
     items.sort((a, b) => b.visitedAt - a.visitedAt);

--- a/src/app/pages/settings/settings.component.ts
+++ b/src/app/pages/settings/settings.component.ts
@@ -7,7 +7,7 @@ import {combineLatest} from "rxjs";
 import {MatDividerModule} from "@angular/material/divider";
 import {MatSlideToggleModule} from "@angular/material/slide-toggle";
 import {CodeSyntax, Settings, SettingsService} from "../../../shared/services/settings.service";
-import {PageScrollBehavior} from "../../../shared/services/page.service";
+import {PageScrollBehavior, PageService} from "../../../shared/services/page.service";
 
 interface AItem<T> {
   readonly value: T;
@@ -54,10 +54,13 @@ export class SettingsComponent implements OnInit {
   readonly codeSyntax: FormControl<CodeSyntax | null> = new FormControl(CodeSyntax.redscript);
 
   constructor(private readonly settingsService: SettingsService,
+              private readonly pageService: PageService,
               private readonly dr: DestroyRef) {
   }
 
   ngOnInit(): void {
+    this.pageService.updateTitle('NativeDB');
+
     this.settingsService.settings$.pipe(takeUntilDestroyed(this.dr)).subscribe(this.onSettingsLoaded.bind(this));
     combineLatest([this.settingsService.clipboard$, this.settingsService.code$])
       .pipe(takeUntilDestroyed(this.dr))

--- a/src/shared/services/page.service.ts
+++ b/src/shared/services/page.service.ts
@@ -26,6 +26,11 @@ export class PageService {
     this.scrollSubject.next(this.scrollBehavior);
   }
 
+  updateTitle(title: string): void {
+    const $title = document.querySelector('head title')! as HTMLTitleElement;
+    $title.textContent = title;
+  }
+
   private onScrollBehaviorChanged(behavior: PageScrollBehavior): void {
     this.scrollBehavior = behavior;
   }


### PR DESCRIPTION
- integrate `PageService` to update document title dynamically
- apply title updates for objects/global functions/enums/bitfields
- restore to default title for settings/readme/recent visits/bookmarks

Closes #229