### PR TITLE
fix: the menu hiding page content on mobile

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,11 +1,11 @@
 <ndb-toolbar (toggle)="toggleTabs()"></ndb-toolbar>
 
 <section>
-  <ndb-tabs [style.display]="displayTabs"></ndb-tabs>
+  <ndb-tabs [style.display]="displayTabs()"></ndb-tabs>
 
   <div #page
        class="page"
-       [style.display]="displayPage">
+       [style.display]="displayPage()">
     <router-outlet></router-outlet>
   </div>
 </section>


### PR DESCRIPTION
- use `viewChild` instead of `@ViewChild`
- use computed values instead of getters for UI states
- remove redundant types declaration when using `inject`

Closes #234